### PR TITLE
MoE - Add global batch load balancing loss

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -121,6 +121,52 @@ def sequence_load_balancing_loss_func(
     return seq_aux_loss
 
 
+def global_batch_load_balancing_loss_func(
+    probs: torch.Tensor,
+    routing_map: torch.Tensor,
+    moe_aux_loss_coeff: float,
+    sequence_partition_group=None,
+):
+    """
+    Calculate the auxiliary loss in global-batch level.
+    Refer to https://arxiv.org/abs/2501.11873 for details.
+
+    Args:
+        probs (torch.Tensor): Softmax probabilities output by the router for each token.
+                              Shape in [num_tokens, num_experts].
+        routing_map (torch.Tensor): Mapping of tokens to experts assignment.
+                                    Shape in [num_tokens, num_experts].
+        moe_aux_loss_coeff (float): Scaling coefficient for the auxiliary loss.
+        sequence_partition_group (optional): The parallel group over which the sequence is
+                                             partitioned. If None, no partitioning is applied.
+                                             Defaults to None.
+
+    Returns:
+        torch.Tensor: The sequence auxiliary loss for load balancing.
+    """
+    routing_prob = probs.mean(0)
+
+    routing_count = routing_map.int().sum(0)
+    torch.distributed.nn.all_reduce(routing_count, op=torch.distributed.ReduceOp.SUM, group=parallel_state.get_data_parallel_group())
+
+    # If the sequence is partitioned by certain parallelism strategies like Sequence Parallelism
+    # or Context Parallelism, compute the gradient of the auxiliary loss with respect to the full
+    # sequence.
+    if sequence_partition_group is not None:
+        routing_prob /= sequence_partition_group.size()
+        routing_prob_count = torch.stack([routing_prob, routing_count])
+        torch.distributed.nn.all_reduce(routing_prob_count, op=torch.distributed.ReduceOp.SUM, group=sequence_partition_group)
+        routing_prob, routing_count = routing_prob_count[0], routing_prob_count[1]
+
+    routing_freq = routing_count / routing_count.sum()
+
+    num_experts = probs.shape[-1]
+    global_batch_aux_loss = num_experts * (routing_freq * routing_prob).sum()
+    global_batch_aux_loss *= moe_aux_loss_coeff
+
+    return global_batch_aux_loss
+
+
 def z_loss_func(logits, z_loss_coeff):
     """Encourages the router's logits to remain small to enhance stability.
     Please refer to the ST-MoE paper (https://arxiv.org/pdf/2202.08906.pdf) for details.

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -13,6 +13,7 @@ from megatron.core.transformer.moe.moe_utils import (
     MoEAuxLossAutoScaler,
     save_to_aux_losses_tracker,
     sequence_load_balancing_loss_func,
+    global_batch_load_balancing_loss_func,
     sinkhorn,
     switch_load_balancing_loss_func,
     topk_softmax_with_capacity,
@@ -277,6 +278,46 @@ class TopKRouter(Router):
 
         return probs, routing_map
 
+    def global_batch_loss_load_balancing(self, logits: torch.Tensor):
+        """Apply global-batch-loss-based load balancing to the logits tensor.
+
+        Args:
+            logits (torch.Tensor): The logits tensor after gating, shape: [num_tokens, num_experts].
+
+        Returns:
+            probs (torch.Tensor): The probabilities of token to experts assignment.
+            routing_map (torch.Tensor): The mask of token to experts assignment.
+        """
+
+        probs, routing_map, tokens_per_expert = topk_softmax_with_capacity(
+            logits,
+            self.topk,
+            capacity_factor=self.config.moe_expert_capacity_factor,
+            pad_to_capacity=self.config.moe_pad_expert_input_to_capacity,
+            drop_policy=self.config.moe_token_drop_policy,
+            use_pre_softmax=self.config.moe_router_pre_softmax,
+            num_groups=self.config.moe_router_num_groups,
+            group_topk=self.config.moe_router_group_topk,
+            scaling_factor=self.config.moe_router_topk_scaling_factor,
+            deterministic_mode=self.config.deterministic_mode,
+            score_function=self.score_function,
+            expert_bias=self.expert_bias,
+        )
+
+        if self.training and torch.is_grad_enabled():
+            # Apply sequence-auxiliary load balancing loss
+            scores = self.compute_routing_scores_for_aux_loss(logits)
+            aux_loss_func = partial(
+                global_batch_load_balancing_loss_func,
+                probs=scores,
+                routing_map=routing_map,
+            )
+            probs = self.apply_load_balancing_loss(
+                activation=probs, load_balancing_loss_func=aux_loss_func
+            )
+
+        return probs, routing_map
+
     def apply_load_balancing_loss(
         self, activation: torch.Tensor, load_balancing_loss_func: Callable
     ):
@@ -396,6 +437,8 @@ class TopKRouter(Router):
             scores, routing_map = self.aux_loss_load_balancing(logits)
         elif self.routing_type == "seq_aux_loss":
             scores, routing_map = self.seq_aux_loss_load_balancing(logits, bsz, seq_length)
+        elif self.routing_type == "global_batch_loss":
+            scores, routing_map = self.global_batch_loss_load_balancing(logits)
         elif self.routing_type == "none":
             # A naive top-k routing without load balancing
             scores, routing_map, _ = topk_softmax_with_capacity(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -334,10 +334,12 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_router_load_balancing_type: str = "aux_loss"
     """The load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss
-    used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used
-    in DeepSeekV2 and DeepSeekV3, which computes the loss for each individual sample; "sinkhorn"
-    corresponds to the balancing algorithm used in S-BASE, and "none" implies no load balancing.
-    The default is "aux_loss"."""
+    used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the loss used in DeepSeekV2,
+    which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing
+    algorithm used in S-BASE; "global_batch" corresponds to the global batch load balancing loss
+    (see https://arxiv.org/abs/2501.11873 for details), and "none" implies no load balancing. The
+    default is "aux_loss"."""
+
 
     moe_router_topk: int = 2
     """Number of experts to route to for each token."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2500,9 +2500,9 @@ def _add_moe_args(parser):
                        'Upcycling is implemented on the top of distributed checkpointing, so it supports parallel modes different from the dense model.')
     # Router arguments
     group.add_argument('--moe-router-load-balancing-type', type=str,
-                       choices=['aux_loss', 'seq_aux_loss', 'sinkhorn', 'none'],
+                       choices=['aux_loss', 'seq_aux_loss', 'sinkhorn', 'global_batch_loss', 'none'],
                        default='aux_loss',
-                       help='Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used in DeepSeekV2, which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing algorithm used in S-BASE, and "none" implies no load balancing. The default is "aux_loss".')
+                       help='Determines the load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the load balancing loss used in DeepSeekV2, which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing algorithm used in S-BASE; "global_batch_loss" corresponds to the global-batch load balancing loss (see https://arxiv.org/abs/2501.11873 for details), and "none" implies no load balancing. The default is "aux_loss".')
     group.add_argument('--moe-router-dtype', type=str,
                        choices=['fp32', 'fp64'],
                        default=None,


### PR DESCRIPTION
Add support for global batch load balancing loss. Use `--moe-router-load-balancing-type global_batch_loss` to enable.