### PR TITLE
MoE - Support fine-grained recompute for MoE layer

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -124,6 +124,21 @@ class MoELayer(BaseMoELayer):
             if self.shared_expert_overlap:
                 self.token_dispatcher.set_shared_experts(self.shared_experts)
 
+    def _set_moe_layer_recompute(self):
+        if self.moe_layer_recompute:
+            if isinstance(self.config.moe_layer_recompute_freq, int):
+                self.moe_layer_recompute = (
+                    ((self.layer_number - 1) % self.config.moe_layer_recompute_freq) == 0
+                )
+            else:
+                self.moe_layer_recompute = (
+                    bool(self.config.moe_layer_recompute_freq[self.layer_number - 1])
+                )
+
+    def set_layer_number(self, layer_number: int):
+        super(MoELayer, self).set_layer_number(layer_number)
+        self._set_moe_layer_recompute()
+
     def forward(self, hidden_states: torch.Tensor):
         if (
             self.training

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -448,6 +448,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_layer_recompute: bool = False
     """Memory optimization: checkpointing moe_layer to save actiavtion memory."""
 
+    moe_layer_recompute_freq: int = None
+    """Frequency to enable MoE layer recompute."""
+
     moe_permute_fusion: bool = False
     """Fuse token rearrangement ops during token dispatching."""
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2497,6 +2497,8 @@ def _add_moe_args(parser):
     group.add_argument('--moe-layer-recompute', action='store_true',
                        help='Enable checkpointing for moe_layer, should be used when memory is not sufficient. '
                        'Deprecated. Use "--recompute-granularity selective --recompute-modules moe" instead.')
+    group.add_argument('--moe-layer-recompute-freq', type=moe_freq_type, default=1,
+                       help='Frequency to enable MoE layer recompute.')
     group.add_argument('--moe-extended-tp', action='store_true',
                        help='Deprecated. Use --expert-tensor-parallel-size instead.')
     group.add_argument('--moe-use-upcycling', action='store_true',


### PR DESCRIPTION
Adds fine-grained MoE recompute support. Use `--moe-layer-recompute-freq` to specify layers to recompute.