### PR TITLE
Data Loader - Improve dataset weighted blending

### DIFF
--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -199,13 +199,25 @@ class BlendedMegatronDatasetBuilder(object):
         ##
         elif self.config.blend:
             prefixes, weights = self.config.blend
+            scale_shuffle_weights = None
+            if self.config.scale_shuffle:
+                if weights is None:
+                    log_single_rank(
+                        logger,
+                        logging.INFO,
+                        f"scale_shuffle is enabled but weights are None, setting all weights to 1.0",
+                    )
+                    scale_shuffle_weights = [1.0] * len(prefixes)
+                else:
+                    scale_shuffle_weights = weights
+                    weights = None
             if weights is not None:
                 weights = normalize(weights)
 
             split = self.config.split_matrix
 
             # Blend consists of a single prefix
-            if len(prefixes) == 1 and weights is None:
+            if len(prefixes) == 1 and weights is None and not self.config.scale_shuffle:
                 return self._build_megatron_dataset_splits(prefixes[0], split, self.sizes)
 
             # Build the mid-level datasets
@@ -222,7 +234,7 @@ class BlendedMegatronDatasetBuilder(object):
 
             # Build each dataset in parallel
             megatron_datasets = self._build_megatron_datasets_parallel(
-                prefixes, split, sizes_per_dataset_buffer
+                prefixes, split, sizes_per_dataset_buffer, scale_shuffle_weights
             )
 
             # Build the top-level datasets
@@ -277,12 +289,24 @@ class BlendedMegatronDatasetBuilder(object):
                 # Blend is provided for the split
                 blend = self.config.blend_per_split[i]
                 if blend is not None:
+                    scale_shuffle_weights = None
+                    if self.config.scale_shuffle:
+                        if weights is None:
+                            log_single_rank(
+                                logger,
+                                logging.INFO,
+                                f"scale_shuffle is enabled but weights are None, setting all weights to 1.0",
+                            )
+                            scale_shuffle_weights = [1.0] * len(prefixes)
+                        else:
+                            scale_shuffle_weights = weights
+                            weights = None
                     prefixes, weights = blend
                     if weights is not None:
                         weights = normalize(weights)
 
                     # Blend consists of a sigle prefix
-                    if len(prefixes) == 1:
+                    if len(prefixes) == 1 and not self.config.scale_shuffle:
                         blended_datasets[i] = self._build_megatron_dataset_splits(
                             prefixes[0], split_spoof, sizes_spoof
                         )[i]
@@ -305,7 +329,7 @@ class BlendedMegatronDatasetBuilder(object):
 
                     # Build each dataset in parallel
                     megatron_datasets = self._build_megatron_datasets_parallel(
-                        prefixes, split_spoof, sizes_per_dataset_buffer
+                        prefixes, split_spoof, sizes_per_dataset_buffer, scale_shuffle_weights
                     )[i]
 
                     # Build top-level dataset
@@ -341,7 +365,8 @@ class BlendedMegatronDatasetBuilder(object):
             return blended_datasets
 
     def _build_megatron_datasets_parallel(
-        self, prefixes: List[str], split: List[float], sizes_per_dataset: List[List[int]]
+        self, prefixes: List[str], split: List[float], sizes_per_dataset: List[List[int]],
+        scale_shuffle_weights: Optional[List[float]],
     ) -> List[List[Optional[MegatronDataset]]]:
         """Build the megatron datasets for a list of prefixes in parallel
 
@@ -352,6 +377,9 @@ class BlendedMegatronDatasetBuilder(object):
 
             sizes_per_dataset (List[List[int]]): The number of samples to request
             per MegatronDataset per spilt
+
+            scale_shuffle_weights (Optional[List[float]]): When scale-shuffle
+            is enabled, weight for each MegatronDataset.
 
         Returns:
             List[List[Optional[MegatronDataset]]]: For each split, have a list of
@@ -365,6 +393,7 @@ class BlendedMegatronDatasetBuilder(object):
             prefixes: List[str],
             split: List[float],
             sizes_per_dataset: List[List[int]],
+            scale_shuffle_weights: Optional[List[float]],
         ) -> None:
             with ThreadPoolExecutor(max_workers=num_workers) as executor:
                 all_futures = []
@@ -376,6 +405,7 @@ class BlendedMegatronDatasetBuilder(object):
                             split,
                             sizes_per_dataset[i],
                             False,  # synchronize_ranks, barrier is called in this function
+                            None if scale_shuffle_weights is None else scale_shuffle_weights[i],
                         )
                     )
                 for future in all_futures:
@@ -401,7 +431,7 @@ class BlendedMegatronDatasetBuilder(object):
                     # i.e. meant for serial build, do not scale up.
                     num_workers *= min(2, max(1, torch.cuda.device_count()))
                 _threading_helper(
-                    megatron_datasets, num_workers, prefixes, split, sizes_per_dataset
+                    megatron_datasets, num_workers, prefixes, split, sizes_per_dataset, scale_shuffle_weights
                 )
 
             torch.distributed.barrier()
@@ -414,10 +444,11 @@ class BlendedMegatronDatasetBuilder(object):
                     prefixes,
                     split,
                     sizes_per_dataset,
+                    scale_shuffle_weights,
                 )
         else:
             _threading_helper(
-                megatron_datasets, num_dataset_builder_threads, prefixes, split, sizes_per_dataset
+                megatron_datasets, num_dataset_builder_threads, prefixes, split, sizes_per_dataset, scale_shuffle_weights
             )
 
         return megatron_datasets
@@ -428,6 +459,7 @@ class BlendedMegatronDatasetBuilder(object):
         split: List[float],
         sizes: List[int],
         synchronize_ranks: bool = True,
+        scale_shuffle_weight: Optional[float] = None,
     ) -> List[Optional[MidLevelDataset]]:
         """Build each MidLevelDataset split from a single LowLevelDataset
 
@@ -442,6 +474,8 @@ class BlendedMegatronDatasetBuilder(object):
             synchronize_ranks (bool): Whether to call barrier for rank-0 / barrier / other-ranks
                 behavior. Set to False when we enforce this behavior at higher level.
 
+            scale_shuffle_weight (Optional[float]): When scale-shuffle is enabled, weight for current dataset splits.
+
         Returns:
             List[Optional[MidLevelDataset]]: The MidLevelDataset (or None) per split
         """
@@ -453,7 +487,10 @@ class BlendedMegatronDatasetBuilder(object):
             return [None] * len(Split)
 
         # Build the low level dataset
-        low_level_dataset = self.cls.build_low_level_dataset(dataset_path, self.config)
+        dataset_args = []
+        if scale_shuffle_weight is not None:
+            dataset_args.append(scale_shuffle_weight)
+        low_level_dataset = self.cls.build_low_level_dataset(dataset_path, self.config, *dataset_args)
 
         # Build the split indices for the low level dataset
         num_elements = self.cls.numel_low_level_dataset(low_level_dataset)
@@ -472,6 +509,9 @@ class BlendedMegatronDatasetBuilder(object):
             if split[i] is None:
                 mid_level_datasets.append(None)
             else:
+                dataset_args = []
+                if scale_shuffle_weight is not None:
+                    dataset_args.append(scale_shuffle_weight)
                 mid_level_datasets.append(
                     self.build_generic_dataset(
                         self.cls,
@@ -483,6 +523,7 @@ class BlendedMegatronDatasetBuilder(object):
                         sizes[i],
                         _split,
                         self.config,
+                        *dataset_args
                     )
                 )
 

--- a/megatron/core/datasets/blended_megatron_dataset_config.py
+++ b/megatron/core/datasets/blended_megatron_dataset_config.py
@@ -63,6 +63,10 @@ class BlendedMegatronDatasetConfig:
     tokenizer: Optional[MegatronTokenizer] = None
     """The MegatronTokenizer instance. Required for datasets that do online tokenization."""
 
+    scale_shuffle: bool = False
+    """Whether to enable scale-shuffle at lowest-level datasets.
+    """
+
     def __post_init__(self) -> None:
         """Do asserts and set fields post init"""
         if self.blend_per_split is not None and any(self.blend_per_split):

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -16,6 +16,7 @@ from megatron.core.datasets.megatron_tokenizer import MegatronTokenizer
 from megatron.core.datasets.utils import Split
 from megatron.core.datasets.utils_s3 import S3Config, is_s3_path
 from megatron.core.utils import log_single_rank
+from megatron.training import get_args
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,7 @@ class GPTDataset(MegatronDataset):
         num_samples: Optional[int],
         index_split: Split,
         config: GPTDatasetConfig,
+        scale_shuffle_weight: Optional[float] = None,
     ) -> None:
         super().__init__(
             indexed_dataset, dataset_path, indexed_indices, num_samples, index_split, config
@@ -109,6 +111,8 @@ class GPTDataset(MegatronDataset):
         except Exception:
             self._pad_token_id = _PAD_TOKEN_ID
 
+        self.scale_shuffle_weight = scale_shuffle_weight
+
         (self.document_index, self.sample_index, self.shuffle_index) = (
             self._build_document_sample_shuffle_indices()
         )
@@ -129,13 +133,18 @@ class GPTDataset(MegatronDataset):
         return low_level_dataset.sequence_lengths.shape[0]
 
     @staticmethod
-    def build_low_level_dataset(dataset_path: str, config: GPTDatasetConfig) -> IndexedDataset:
+    def build_low_level_dataset(
+        dataset_path: str,
+        config: GPTDatasetConfig,
+        scale_shuffle_weight: Optional[float] = None) -> IndexedDataset:
         """Abstract method implementation
 
         Args:
             dataset_path (str): The real path prefix to the IndexedDataset .bin and .idx files
 
             config (GPTDatasetConfig): The config
+
+            scale_shuffle_weight (Optional[float]): When scale-shuffle is enabled, weight for current low-level dataset.
 
         Returns:
             IndexedDataset: The underlying IndexedDataset
@@ -147,7 +156,13 @@ class GPTDataset(MegatronDataset):
                 mmap=config.mmap_bin_files,
                 s3_config=S3Config(path_to_idx_cache=config.s3_cache_path),
             )
-        return IndexedDataset(dataset_path, multimodal=False, mmap=config.mmap_bin_files)
+        return IndexedDataset(
+            dataset_path,
+            multimodal=False,
+            mmap=config.mmap_bin_files,
+            scale_shuffle_weight=scale_shuffle_weight,
+            scale_shuffle_seed=get_args().seed,
+            split_matrix=config.split_matrix)
 
     def __len__(self) -> int:
         """Abstract method implementation
@@ -409,7 +424,7 @@ class GPTDataset(MegatronDataset):
 
             # Build the document index
             document_index = _build_document_index(
-                self.indices, num_epochs, numpy_random_state, separate_final_epoch
+                self.indices, num_epochs, numpy_random_state, separate_final_epoch, self.scale_shuffle_weight
             )
 
             drop_last_partial_sequence = True
@@ -450,11 +465,11 @@ class GPTDataset(MegatronDataset):
             # Build the shuffle index
             if separate_final_epoch:
                 shuffle_index = _build_shuffle_index(
-                    num_samples_sans_final_epoch, sample_index.shape[0] - 1, numpy_random_state
+                    num_samples_sans_final_epoch, sample_index.shape[0] - 1, numpy_random_state, self.scale_shuffle_weight
                 )
             else:
                 shuffle_index = _build_shuffle_index(
-                    sample_index.shape[0] - 1, sample_index.shape[0] - 1, numpy_random_state
+                    sample_index.shape[0] - 1, sample_index.shape[0] - 1, numpy_random_state, self.scale_shuffle_weight
                 )
 
             if path_to_cache:
@@ -558,6 +573,7 @@ def _build_document_index(
     num_epochs: int,
     numpy_random_state: numpy.random.RandomState,
     separate_final_epoch: bool,
+    scale_shuffle_weight: Optional[float],
 ) -> numpy.ndarray:
     """Build an array with length = num epochs * num documents
 
@@ -570,6 +586,8 @@ def _build_document_index(
 
         separate_final_epoch (bool): Whether to exclude the last epoch from the global shuffle
 
+        scale_shuffle_weight (Optional[float]): When scale-shuffle is enabled, weight for current low-level dataset
+
     Returns:
         numpy.ndarray: The document index
     """
@@ -578,16 +596,17 @@ def _build_document_index(
         document_index[:] = documents
         document_index = document_index.reshape(-1)
         document_index = document_index.astype(numpy.int32)
-        numpy_random_state.shuffle(document_index)
+        if scale_shuffle_weight is None:
+            numpy_random_state.shuffle(document_index)
         return document_index
 
-    doc_idx_first = _build_document_index(documents, num_epochs - 1, numpy_random_state, False)
-    doc_idx_last = _build_document_index(documents, 1, numpy_random_state, False)
+    doc_idx_first = _build_document_index(documents, num_epochs - 1, numpy_random_state, False, scale_shuffle_weight)
+    doc_idx_last = _build_document_index(documents, 1, numpy_random_state, False, scale_shuffle_weight)
     return numpy.concatenate((doc_idx_first, doc_idx_last))
 
 
 def _build_shuffle_index(
-    num_samples: int, total_size: int, numpy_random_state: numpy.random.RandomState
+    num_samples: int, total_size: int, numpy_random_state: numpy.random.RandomState, scale_shuffle_weight: Optional[float]
 ) -> numpy.ndarray:
     """Build the range [0, size) and shuffle
 
@@ -599,6 +618,8 @@ def _build_shuffle_index(
 
         numpy_random_state (numpy.random.RandomState): The NumPy random state
 
+        scale_shuffle_weight (Optional[float]): When scale-shuffle is enabled, weight for current low-level dataset
+
     Returns:
         numpy.ndarray: The shuffle index
     """
@@ -607,12 +628,14 @@ def _build_shuffle_index(
         dtype_ = numpy.int64
 
     shuffle_idx_first = numpy.arange(start=0, stop=num_samples, step=1, dtype=dtype_)
-    numpy_random_state.shuffle(shuffle_idx_first)
+    if scale_shuffle_weight is None:
+        numpy_random_state.shuffle(shuffle_idx_first)
     if num_samples == total_size:
         return shuffle_idx_first
 
     shuffle_idx_last = numpy.arange(start=num_samples, stop=total_size, step=1, dtype=dtype_)
-    numpy_random_state.shuffle(shuffle_idx_last)
+    if scale_shuffle_weight is None:
+        numpy_random_state.shuffle(shuffle_idx_last)
 
     return numpy.concatenate((shuffle_idx_first, shuffle_idx_last))
 

--- a/megatron/core/datasets/indexed_dataset.py
+++ b/megatron/core/datasets/indexed_dataset.py
@@ -163,6 +163,7 @@ class _IndexWriter(object):
         sequence_lengths: List[int],
         sequence_modes: Optional[List[int]],
         document_indices: List[int],
+        sequence_pointers: Optional[List[int]] = None,
     ) -> None:
         """Write the index (.idx) file
 
@@ -172,8 +173,11 @@ class _IndexWriter(object):
             sequence_modes (Optional[List[int]]): The mode of each sequences
 
             document_indices (List[int]): The seqyebce indices demarcating the end of each document
+
+            sequence_pointers (Optional[List[int]]): The pointer to the beginning of each sequence
         """
-        sequence_pointers = self._sequence_pointers(sequence_lengths)
+        if sequence_pointers is None:
+            sequence_pointers = self._sequence_pointers(sequence_lengths)
 
         # the number of sequences in the dataset
         sequence_count = len(sequence_lengths)
@@ -230,7 +234,27 @@ class _IndexReader(object):
         multimodal (bool): Whether the dataset is multimodal
     """
 
-    def __init__(self, idx_path: str, multimodal: bool) -> None:
+    def __init__(
+            self,
+            idx_path: str,
+            multimodal: bool,
+            scale_shuffle_weight: Optional[float] = None,
+            scale_shuffle_seed: Optional[int] = None,
+            split_matrix: Optional[List[Tuple[float, float]]] = None,
+        ) -> None:
+        if scale_shuffle_weight is not None:
+            scale_shuffle_idx_path = idx_path + '.scale_shuffle'
+            scale_shuffle_idx_exist = os.path.isfile(scale_shuffle_idx_path)
+            if scale_shuffle_idx_exist:
+                self._load_index(scale_shuffle_idx_path, multimodal)
+            else:
+                self._load_index(idx_path, multimodal)
+                self._build_save_apply_scale_shuffle_index(
+                    scale_shuffle_weight, scale_shuffle_seed, split_matrix, scale_shuffle_idx_path)
+        else:
+            self._load_index(idx_path, multimodal)
+ 
+    def _load_index(self, idx_path: str, multimodal: bool) -> None:
 
         log_single_rank(logger, logging.INFO, f"Load the {type(self).__name__} from {idx_path}")
 
@@ -339,6 +363,105 @@ class _IndexReader(object):
             self.sequence_lengths[idx],
             self.sequence_modes[idx] if self.sequence_modes is not None else None,
         )
+
+    def _build_save_apply_scale_shuffle_index(
+            self,
+            scale_shuffle_weight: float,
+            scale_shuffle_seed: int,
+            split_matrix: Optional[List[Tuple[float, float]]],
+            scale_shuffle_idx_path: str,
+        ):
+        g = torch.Generator()
+        g.manual_seed(scale_shuffle_seed)
+        real_doc_cnt = self.document_count - 1
+        # 1. Isolate document indices from different splits before scaling and shuffling them
+        if split_matrix is None:
+            split_doc_idx_ranges = [[1, self.document_count]]
+        else:
+            split_doc_idx_ranges = [
+                (
+                    [int(y * real_doc_cnt) + 1 for y in x]
+                    if x is not None
+                    else [0, 0]
+                )
+                for x in split_matrix
+            ]
+        # 2. Scale and shuffle the document indices, do intra-epoch shuffle and keep inter-epoch order
+        scale_shuffle_weight_fracs = [1] * int(scale_shuffle_weight) + [scale_shuffle_weight - int(scale_shuffle_weight)]
+        scaled_shuffled_doc_idx_indices = []
+        for i in split_doc_idx_ranges:
+            indices = []
+            for scale_frac in scale_shuffle_weight_fracs:
+                perm_size = i[1] - i[0]
+                perm = torch.randperm(perm_size, generator=g).tolist()
+                perm = perm[:int(perm_size * scale_frac)]
+                indices += [x + i[0] for x in perm]
+            scaled_shuffled_doc_idx_indices += indices
+        scaled_document_count = len(scaled_shuffled_doc_idx_indices) + 1
+
+        # 3. Generate new consecutive sequence index ranges according to shuffled document indices
+        scaled_document_indices = [0] * scaled_document_count
+        for i, doc_idx_idx in enumerate(scaled_shuffled_doc_idx_indices):
+            num_seq_in_doc = self.document_indices[doc_idx_idx] - self.document_indices[doc_idx_idx - 1]
+            scaled_document_indices[i + 1] = scaled_document_indices[i] + num_seq_in_doc
+        # 4. Generate new sequence lengths, pointers and modes according to shuffled document indices
+        scaled_sequence_count = scaled_document_indices[-1]
+        scaled_sequence_lengths = [0] * scaled_sequence_count
+        scaled_sequence_pointers = [0] * scaled_sequence_count
+        scaled_sequence_modes = None
+        if self.sequence_modes is not None:
+            scaled_sequence_modes = [0] * scaled_sequence_count
+        scaled_sequence_idx = 0
+        for i, doc_idx_idx in enumerate(scaled_shuffled_doc_idx_indices):
+            beg_seq_idx = self.document_indices[doc_idx_idx - 1]
+            end_seq_idx = self.document_indices[doc_idx_idx]
+            for seq_idx in range(beg_seq_idx, end_seq_idx):
+                scaled_sequence_lengths[scaled_sequence_idx] = self.sequence_lengths[seq_idx]
+                scaled_sequence_pointers[scaled_sequence_idx] = self.sequence_pointers[seq_idx]
+                if self.sequence_modes is not None:
+                    scaled_sequence_modes[scaled_sequence_idx] = self.sequence_modes[seq_idx]
+                scaled_sequence_idx += 1
+
+        # 5. Save scale-shuffle index
+        if torch.distributed.is_initialized():
+            local_rank = torch.distributed.get_rank() % torch.cuda.device_count()
+        else:
+            local_rank = 0
+        if local_rank == 0:
+            with _IndexWriter(scale_shuffle_idx_path + '.tmp', numpy.int32) as writer:
+                writer.write(scaled_sequence_lengths, scaled_sequence_modes, scaled_document_indices, scaled_sequence_pointers)
+            # Make sure full file content is visible to other ranks
+            os.rename(scale_shuffle_idx_path + '.tmp', scale_shuffle_idx_path)
+
+        # 6. Apply scale-shuffle index
+        self.sequence_count = scaled_sequence_count
+        self.document_count = scaled_document_count
+
+        scaled_sequence_lengths_np = numpy.array(scaled_sequence_lengths, dtype=self.sequence_lengths.dtype)
+        del self.sequence_lengths
+        del scaled_sequence_lengths
+        self.sequence_lengths = scaled_sequence_lengths_np
+
+        scaled_sequence_pointers_np = numpy.array(scaled_sequence_pointers, dtype=self.sequence_pointers.dtype)
+        del self.sequence_pointers
+        del scaled_sequence_pointers
+        self.sequence_pointers = scaled_sequence_pointers_np
+
+        scaled_document_indices_np = numpy.array(scaled_document_indices, dtype=self.document_indices.dtype)
+        del self.document_indices
+        del scaled_document_indices
+        self.document_indices = scaled_document_indices_np
+
+        if self.sequence_modes is not None:
+            scaled_sequence_modes_np = numpy.array(scaled_sequence_modes, dtype=self.sequence_modes.dtype)
+            del self.sequence_modes
+            del scaled_sequence_modes
+            self.sequence_modes = scaled_sequence_modes_np
+
+        # 7. Clear mmap of original index
+        del self.bin_buffer
+        self.bin_buffer_mmap._mmap.close()
+        del self.bin_buffer_mmap
 
 
 class _BinReader(ABC):
@@ -514,6 +637,12 @@ class IndexedDataset(torch.utils.data.Dataset):
         mmap (bool): Whether to mmap the .bin files. Defaults to True.
 
         s3_config (Optional[S3Config]): Supplied only for data stored on S3. IndexedDataset downloads the index (.idx) file to `s3_config.path_to_idx_cache` and streams data from the data (.bin) file in `s3_config.bin_chunk_nbytes` blocks. Note that `mmap` must be disabled for S3 data loading. Defaults to None.
+
+        scale_shuffle_weight (Optional[float]): The scaling weight in scale-and-shuffle.
+
+        scale_shuffle_seed (Optional[int]): Random seed used in scale-and-shuffle.
+
+        split_matrix (Optional[List[Tuple[float, float]]]): Train/valid/test splits for scale-and-shuffle.
     """
 
     def __init__(
@@ -522,12 +651,18 @@ class IndexedDataset(torch.utils.data.Dataset):
         multimodal: bool = False,
         mmap: bool = True,
         s3_config: Optional[S3Config] = None,
+        scale_shuffle_weight: Optional[float] = None,
+        scale_shuffle_seed: Optional[int] = None,
+        split_matrix: Optional[List[Tuple[float, float]]] = None,
     ) -> None:
         super().__init__()
         self.path_prefix = None
         self.multimodal = None
         self.mmap = None
         self.s3_config = None
+        self.scale_shuffle_weight = None
+        self.scale_shuffle_seed = None
+        self.split_matrix = None
 
         self.index = None
         self.bin_reader = None
@@ -537,10 +672,11 @@ class IndexedDataset(torch.utils.data.Dataset):
             cache_idx_path = os.path.join(s3_config.path_to_idx_cache, os.path.basename(idx_path))
             maybe_download_file(idx_path, cache_idx_path)
 
-        self.initialize(path_prefix, multimodal, mmap, s3_config)
+        self.initialize(path_prefix, multimodal, mmap, s3_config, scale_shuffle_weight, scale_shuffle_seed, split_matrix)
 
     def initialize(
-        self, path_prefix: str, multimodal: bool, mmap: bool, s3_config: Optional[S3Config]
+        self, path_prefix: str, multimodal: bool, mmap: bool, s3_config: Optional[S3Config],
+        scale_shuffle_weight: Optional[float], scale_shuffle_seed: Optional[int], split_matrix: Optional[List[Tuple[float, float]]]
     ) -> None:
         """Initialize the dataset
 
@@ -555,6 +691,12 @@ class IndexedDataset(torch.utils.data.Dataset):
             mmap (bool): Whether to mmap the .bin file
 
             s3_config (Optional[S3Config]): See IndexedDataset docstring for details.
+
+            scale_shuffle_weight (Optional[float]): The scaling weight in scale-and-shuffle.
+
+            scale_shuffle_seed (Optional[int]): Random seed used in scale-and-shuffle.
+
+            split_matrix (Optional[List[Tuple[float, float]]]): Train/valid/test splits for scale-and-shuffle.
         """
         idx_path = get_idx_path(path_prefix)
         bin_path = get_bin_path(path_prefix)
@@ -566,6 +708,9 @@ class IndexedDataset(torch.utils.data.Dataset):
         self.multimodal = multimodal
         self.mmap = mmap
         self.s3_config = s3_config
+        self.scale_shuffle_weight = scale_shuffle_weight
+        self.scale_shuffle_seed = scale_shuffle_seed
+        self.split_matrix = split_matrix
         if mmap:
             assert not s3_config
             self.bin_reader = _MMapBinReader(bin_path)
@@ -577,7 +722,7 @@ class IndexedDataset(torch.utils.data.Dataset):
             )
         else:
             self.bin_reader = _FileBinReader(bin_path)
-        self.index = _IndexReader(idx_path, self.multimodal)
+        self.index = _IndexReader(idx_path, self.multimodal, self.scale_shuffle_weight, self.scale_shuffle_seed, self.split_matrix)
 
     def __getstate__(self) -> Tuple[str, bool, bool, Optional[S3Config]]:
         """Get the state during pickling
@@ -635,17 +780,27 @@ class IndexedDataset(torch.utils.data.Dataset):
             start, stop, step = idx.indices(len(self))
             if step != 1:
                 raise ValueError("Slices into indexed_dataset must be contiguous")
-            sequence_lengths = self.index.sequence_lengths[idx]
+            if self.scale_shuffle_weight is not None:
+                sequences = [
+                    self.bin_reader.read(
+                        dtype=self.index.dtype,
+                        count=self.index.sequence_lengths[i],
+                        offset=self.index.sequence_pointers[i]
+                    )
+                    for i in range(*idx.indices(len(self)))
+                ]
+            else:
+                sequence_lengths = self.index.sequence_lengths[idx]
+                sequence_offsets = list(accumulate(sequence_lengths))
+                sequences = numpy.split(
+                    self.bin_reader.read(
+                        dtype=self.index.dtype,
+                        count=sum(sequence_lengths),
+                        offset=self.index.sequence_pointers[start],
+                    ),
+                    sequence_offsets[:-1],
+                )
             sequence_modes = self.index.sequence_modes[idx] if self.multimodal else None
-            sequence_offsets = list(accumulate(sequence_lengths))
-            sequences = numpy.split(
-                self.bin_reader.read(
-                    dtype=self.index.dtype,
-                    count=sum(sequence_lengths),
-                    offset=self.index.sequence_pointers[start],
-                ),
-                sequence_offsets[:-1],
-            )
             return (sequences, sequence_modes) if sequence_modes is not None else sequences
         else:
             raise TypeError("Unexpected type received for idx: {}".format(type(idx)))

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2319,6 +2319,8 @@ def _add_data_args(parser):
                        help='Number of parallel threads per rank for dataset builder')
     group.add_argument('--s3-cache-path', type=str, default=None,
                        help='Path to cache index files when using s3 dataloader')
+    group.add_argument('--scale-shuffle', action='store_true',
+                       help='Whether to enable scale-shuffle at lowest-level datasets.')
     return parser
 
 

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -281,6 +281,7 @@ def core_gpt_dataset_config_from_args(args):
         eod_mask_loss=args.eod_mask_loss,
         create_attention_mask=args.create_attention_mask_in_dataloader,
         s3_cache_path=args.s3_cache_path,
+        scale_shuffle=args.scale_shuffle,
     )
 
 


### PR DESCRIPTION
Improves dataset weighted blending in the following two aspects:

- Support weight > 1 (oversampling) datasets.
- Keep inter-epoch data order while allowing intra-epoch shuffling.

To achieve this, .idx of IndexedDataset and index of GPTDataset needs to be re-built to provide a virtual view of original dataset that is properly scaled and shuffled. Meanwhile, weighting and shuffling in higher-level datasets and callers need to be disabled.

To enable this feature, toggle `--scale-shuffle`, `--dataloader-type single`, and use `--data-args-path` to pass (weight, dataset path) lines from a file.