### PR TITLE
MoE - Support gradient scale and normalization for MoE router

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -69,7 +69,17 @@ class Router(ABC, MegatronModule):
             router_dtype = torch.float32
         elif self.config.moe_router_dtype == 'fp64':
             router_dtype = torch.float64
-        logits = torch.nn.functional.linear(input.to(router_dtype), self.weight.to(router_dtype))
+        if self.config.moe_router_gradient_scale is not None:
+            gradient_scaled_weight = (
+                self.weight.to(router_dtype) * self.config.moe_router_gradient_scale +
+                self.weight.to(router_dtype).detach() * (1 - self.config.moe_router_gradient_scale)
+            )
+            if self.config.moe_router_gradient_scale_normalize:
+                # self.weight.shape is (num_experts, hidden_size) so hidden_size dim is normalized
+                gradient_scaled_weight = torch.nn.functional.normalize(gradient_scaled_weight)
+            logits = torch.nn.functional.linear(input.to(router_dtype), gradient_scaled_weight)
+        else:
+            logits = torch.nn.functional.linear(input.to(router_dtype), self.weight.to(router_dtype))
         return logits
 
     @abstractmethod

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -400,6 +400,12 @@ class TransformerConfig(ModelParallelConfig):
     and decreased for the experts with more assigned tokens.
     The default value 1e-3 is same as that used in DeepSeekV3."""
 
+    moe_router_gradient_scale: float = None
+    """Gradient scale of MoE router weights."""
+
+    moe_router_gradient_scale_normalize: bool = False
+    """When MoE router gradient scaling is enabled, further normalize the weights."""
+
     moe_grouped_gemm: bool = False
     """When there are multiple experts per rank, compress multiple local (potentially small) gemms
     in a single kernel launch to improve the utilization and performance by leveraging the Grouped

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2545,6 +2545,10 @@ def _add_moe_args(parser):
                        'The expert bias is updated based on the number of assigned tokens to each expert in a global batch, '
                        'where the bias is increased for the experts with less assigned tokens and decreased for the experts with more assigned tokens. '
                        'The default value 1e-3 is same as that used in DeepSeekV3.')
+    group.add_argument('--moe-router-gradient-scale', type=float, default=None,
+                       help='Gradient scale of MoE router weights.')
+    group.add_argument('--moe-router-gradient-scale-normalize', action='store_true',
+                       help='When MoE router gradient scaling is enabled, further normalize the weights.')
     group.add_argument('--moe-aux-loss-coeff', type=float, default=0.0,
                        help='Scaling coefficient for the aux loss: a starting value of 1e-2 is recommended.')
     group.add_argument('--moe-z-loss-coeff', type=float, default=None,


### PR DESCRIPTION
Adds gradient scale and normalization option for MoE router by adding `--moe-router-gradient-scale` and `--moe-router-gradient-scale-normalize` options.