### PR TITLE
Checkpoint - Recalculate rampup batch size and data offset

### DIFF
--- a/megatron/legacy/data/data_samplers.py
+++ b/megatron/legacy/data/data_samplers.py
@@ -25,7 +25,8 @@ def build_pretraining_data_loader(dataset, consumed_samples):
             consumed_samples=consumed_samples,
             micro_batch_size=args.micro_batch_size,
             data_parallel_rank=mpu.get_data_parallel_rank(),
-            data_parallel_size=mpu.get_data_parallel_world_size())
+            data_parallel_size=mpu.get_data_parallel_world_size(),
+            dataset_offset=args.dataset_offset)
     elif args.dataloader_type == 'cyclic':
         batch_sampler = MegatronPretrainingRandomSampler(
             dataset,
@@ -34,7 +35,8 @@ def build_pretraining_data_loader(dataset, consumed_samples):
             micro_batch_size=args.micro_batch_size,
             data_parallel_rank=mpu.get_data_parallel_rank(),
             data_parallel_size=mpu.get_data_parallel_world_size(),
-            data_sharding=args.data_sharding)
+            data_sharding=args.data_sharding,
+            dataset_offset=args.dataset_offset)
     elif args.dataloader_type == "external":
         # External dataloaders are passed through. User is expected to provide a
         # torch-compatible dataloader and define samplers, if needed.
@@ -54,10 +56,11 @@ def build_pretraining_data_loader(dataset, consumed_samples):
 class MegatronPretrainingSampler:
 
     def __init__(self, total_samples, consumed_samples, micro_batch_size,
-                 data_parallel_rank, data_parallel_size, drop_last=True):
+                 data_parallel_rank, data_parallel_size, drop_last=True,
+                 dataset_offset=0):
         # Keep a copy of input params for later use.
         self.total_samples = total_samples
-        self.consumed_samples = consumed_samples
+        self.consumed_samples = consumed_samples + dataset_offset
         self.micro_batch_size = micro_batch_size
         self.data_parallel_rank = data_parallel_rank
         self.micro_batch_times_data_parallel_size = \
@@ -67,6 +70,8 @@ class MegatronPretrainingSampler:
         # Sanity checks.
         assert self.total_samples > 0, \
             'no sample to consume: {}'.format(self.total_samples)
+        assert self.consumed_samples >= 0, \
+            'consumed samples {} cannot be negative'.format(self.consumed_samples)
         assert self.consumed_samples < self.total_samples, \
             'no samples left to consume: {}, {}'.format(self.consumed_samples,
                                                         self.total_samples)
@@ -125,11 +130,12 @@ class RandomSeedDataset(Dataset):
 class MegatronPretrainingRandomSampler:
 
     def __init__(self, dataset, total_samples, consumed_samples, micro_batch_size,
-                 data_parallel_rank, data_parallel_size, data_sharding):
+                 data_parallel_rank, data_parallel_size, data_sharding,
+                 dataset_offset=0):
         # Keep a copy of input params for later use.
         self.dataset = dataset
         self.total_samples = total_samples
-        self.consumed_samples = consumed_samples
+        self.consumed_samples = consumed_samples + dataset_offset
         self.micro_batch_size = micro_batch_size
         self.data_parallel_rank = data_parallel_rank
         self.data_parallel_size = data_parallel_size
@@ -142,6 +148,8 @@ class MegatronPretrainingRandomSampler:
         # Sanity checks.
         assert self.total_samples > 0, \
             'no sample to consume: {}'.format(self.total_samples)
+        assert self.consumed_samples >= 0, \
+            'consumed samples {} cannot be negative'.format(self.consumed_samples)
         assert self.micro_batch_size > 0
         assert data_parallel_size > 0
         assert self.data_parallel_rank < data_parallel_size, \

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1993,6 +1993,9 @@ def _add_checkpointing_args(parser):
                             ' Check StrictHandling docs for flags meaning.'
                             ' NOTE: This flag controls only distributed checkpoint'
                             ' load from storage, not loading state dict into the model.')
+    group.add_argument('--infer-rampup-batch-size', action='store_true',
+                       help='Infer rampup batch size from checkpoint, cannot '
+                       'set rampup batch size at the same time.')
     group.add_argument('--ckpt-upload-blob-path', type=str, default=None,
                        help='Azure blob path for checkpoint upload, do not include checkpoint name.')
     group.add_argument('--ckpt-upload-blob-sas-path', type=str, default=None,
@@ -2328,6 +2331,11 @@ def _add_data_args(parser):
                        help='Number of parallel threads per rank for dataset builder')
     group.add_argument('--s3-cache-path', type=str, default=None,
                        help='Path to cache index files when using s3 dataloader')
+    group.add_argument('--dataset-reset-key', type=str, default='',
+                       help='Reset key for the dataset, change this key for '
+                       'new dataset to reset indecies in dataloader.')
+    group.add_argument('--dataset-offset', type=int, default=0,
+                       help='Index offset to previous datasets in dataloader.')
     group.add_argument('--scale-shuffle', action='store_true',
                        help='Whether to enable scale-shuffle at lowest-level datasets.')
     return parser

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1158,6 +1158,34 @@ def load_args_from_checkpoint(
     return args, checkpoint_args
 
 
+def get_args_from_checkpoint(
+    args, load_arg='load', checkpointing_context=None
+):
+    """Get arguments from the checkpoint specified in the
+    arguments.
+    """
+    load_dir = getattr(args, load_arg)
+
+    if load_dir is None:
+        print_rank_0('No load directory specified.')
+        return None
+
+    state_dict, _, _, _ = _load_base_checkpoint(
+        load_dir,
+        args,
+        rank0=True,
+        checkpointing_context=checkpointing_context,
+    )
+
+    if not state_dict or 'args' not in state_dict:
+        print_rank_0('No arguments found in checkpoint.')
+        return None
+
+    checkpoint_args = state_dict['args']
+    setattr(checkpoint_args, 'checkpoint_iteration', state_dict['iteration'])
+    return checkpoint_args
+
+
 def fix_fp8_params_lose_precision_when_loading_dist_ckpt(state_dict):
     """
     When "--fp8-param-gather" and "--use-dist-ckpt" are both enabled, the state dict read from

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -27,7 +27,7 @@ from megatron.legacy import fused_kernels
 from megatron.training import get_adlr_autoresume, get_args, get_tensorboard_writer
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.async_utils import init_persistent_async_worker
-from megatron.training.checkpointing import load_args_from_checkpoint
+from megatron.training.checkpointing import load_args_from_checkpoint, get_args_from_checkpoint, checkpoint_exists
 from megatron.training.global_vars import set_global_variables
 from megatron.training.yaml_arguments import validate_yaml
 
@@ -76,6 +76,35 @@ def initialize_megatron(
             "before initializing LocalCheckpointManager."
         )
         load_args_from_checkpoint(args)
+
+    # Update default args from checkpoint
+    if args.load and checkpoint_exists(args.load):
+        ckpt_args = get_args_from_checkpoint(args)
+        # Recalculate global batch size for rampup
+        assert not(args.infer_rampup_batch_size and args.rampup_batch_size), \
+            "Not allowed to set --rampup-batch-size when using --infer-rampup-batch-size"
+        if args.infer_rampup_batch_size and args.rampup_batch_size is None:
+            prev_avg_batch_size = ckpt_args.consumed_train_samples // ckpt_args.checkpoint_iteration
+            if args.global_batch_size != prev_avg_batch_size:
+                args.rampup_batch_size = [
+                    prev_avg_batch_size,
+                    args.global_batch_size - prev_avg_batch_size,
+                    prev_avg_batch_size * ckpt_args.checkpoint_iteration - 1,
+                ]
+                if args.rank == 0:
+                    print("> setting rampup_batch_size to:", *args.rampup_batch_size, sep=' ')
+        # Set dataset offset for dataloader
+        dataset_reset = (args.dataset_reset_key != getattr(ckpt_args, 'dataset_reset_key', ''))
+        args.dataset_offset = (
+            -ckpt_args.consumed_train_samples if dataset_reset else ckpt_args.dataset_offset
+        )
+        if args.rank == 0:
+            print("> setting dataset_offset to: {}, dataset_reset_key: {} -> {} (reset {})".format(
+                args.dataset_offset,
+                getattr(ckpt_args, 'dataset_reset_key', ''),
+                args.dataset_reset_key,
+                dataset_reset,
+            ))
 
     if args.async_save and args.use_persistent_ckpt_worker:
         init_persistent_async_worker()


### PR DESCRIPTION
Adds support to recalculate rampup batch size and data offset from checkpoint:

- Start batch size: average batch size of previous iterations
- Batch size increment: current batch size - previous average batch size
- Ramp-up samples: equivalent samples in previous iterations
- Dataset offset: subtract consumed train samples if dataset is reset.

Set `--infer-rampup-batch-size` to enable rampup batch size re-calculating.

When changing datasets, use either `--dataset-reset-key dataset-phase1` / `--dataset-reset-key dataset-phase2`, or `--dataset-reset-key $(printf $(md5sum configfile))` to trigger.