### PR TITLE
Logging - Add MoE global batch loss metrics

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -340,7 +340,7 @@ class TransformerConfig(ModelParallelConfig):
     """The load balancing strategy for the router. "aux_loss" corresponds to the load balancing loss
     used in GShard and SwitchTransformer; "seq_aux_loss" corresponds to the loss used in DeepSeekV2,
     which computes the loss for each individual sample; "sinkhorn" corresponds to the balancing
-    algorithm used in S-BASE; "global_batch" corresponds to the global batch load balancing loss
+    algorithm used in S-BASE; "global_batch_loss" corresponds to the global batch load balancing loss
     (see https://arxiv.org/abs/2501.11873 for details), and "none" implies no load balancing. The
     default is "aux_loss"."""
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1513,8 +1513,10 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
     if args.num_experts is not None:
         moe_loss_scale = 1 / get_num_microbatches()
         track_names = []
-        if args.moe_router_load_balancing_type in ["aux_loss", "seq_aux_loss"]:
+        if args.moe_router_load_balancing_type in ["aux_loss", "seq_aux_loss", "global_batch_loss"]:
             track_names.append("load_balancing_loss")
+            if args.moe_router_load_balancing_type == "global_batch_loss":
+                track_names.append("global_batch_tokens_per_expert")
         if args.moe_z_loss_coeff is not None:
             track_names.append("z_loss")
         track_moe_metrics(


### PR DESCRIPTION
MoE aux loss related metrics become whitelist based in latest Megatron-LM. Add global batch loss related metrics to the whitelist.

Also fixed a typo.