### PR TITLE
Algorithm - Support normal distribution initialization for output layers

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -160,9 +160,6 @@ class TransformerConfig(ModelParallelConfig):
     will be set to megatron.core.utils.scaled_init_method_normal(init_method_std) which is torch nn
     init normal with mean=0.0 and std=init_method_std / math.sqrt(2.0 * num_layers)."""
 
-    use_init_method_for_output_layer: bool = False
-    """If True, use the specified init_method for output layer."""
-
     init_method_std: float = 0.02
     """Standard deviation of the zero mean normal for the default initialization method, not used if
     init_method and output_layer_init_method are provided."""
@@ -948,9 +945,6 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.init_method is None:
             self.init_method = init_method_normal(self.init_method_std)
-
-        if self.use_init_method_for_output_layer:
-            self.output_layer_init_method = self.init_method
 
         if self.output_layer_init_method is None:
             self.output_layer_init_method = scaled_init_method_normal(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -160,6 +160,9 @@ class TransformerConfig(ModelParallelConfig):
     will be set to megatron.core.utils.scaled_init_method_normal(init_method_std) which is torch nn
     init normal with mean=0.0 and std=init_method_std / math.sqrt(2.0 * num_layers)."""
 
+    use_init_method_for_output_layer: bool = False
+    """If True, use the specified init_method for output layer."""
+
     init_method_std: float = 0.02
     """Standard deviation of the zero mean normal for the default initialization method, not used if
     init_method and output_layer_init_method are provided."""
@@ -945,6 +948,9 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.init_method is None:
             self.init_method = init_method_normal(self.init_method_std)
+
+        if self.use_init_method_for_output_layer:
+            self.output_layer_init_method = self.init_method
 
         if self.output_layer_init_method is None:
             self.output_layer_init_method = scaled_init_method_normal(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -25,6 +25,7 @@ from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.heterogeneous.heterogeneous_config import HeterogeneousTransformerConfig
 from megatron.core.utils import (
     get_torch_version,
+    init_method_normal,
     is_torch_min_version,
 )
 from megatron.training.activations import squared_relu
@@ -1031,6 +1032,8 @@ def core_transformer_config_from_args(args, config_class=None):
     if args.init_method_xavier_uniform:
         kw_args['init_method'] = torch.nn.init.xavier_uniform_
         kw_args['scaled_init_method'] = torch.nn.init.xavier_uniform_
+    if args.output_layer_init_method_normal:
+        kw_args['output_layer_init_method'] = init_method_normal(args.output_layer_init_method_normal_std)
     if args.group_query_attention:
         kw_args['num_query_groups'] = args.num_query_groups
     else:
@@ -1819,8 +1822,11 @@ def _add_initialization_args(parser):
                        'distribution used for weight initialization.')
     group.add_argument('--init-method-xavier-uniform', action='store_true',
                        help='Enable Xavier uniform parameter initialization')
-    group.add_argument('--use-init-method-for-output-layer', action='store_true',
-                       help='Use the specified init method for output layer.')
+    group.add_argument('--output-layer-init-method-normal', action='store_true',
+                       help='Use normal distribution weight initialization for output layers.')
+    group.add_argument('--output-layer-init-method-normal-std', type=float, default=0.02,
+                       help='Standard deviation of the zero mean normal '
+                       'distribution used for weight initialization for output layers.')
 
     return parser
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1819,6 +1819,8 @@ def _add_initialization_args(parser):
                        'distribution used for weight initialization.')
     group.add_argument('--init-method-xavier-uniform', action='store_true',
                        help='Enable Xavier uniform parameter initialization')
+    group.add_argument('--use-init-method-for-output-layer', action='store_true',
+                       help='Use the specified init method for output layer.')
 
     return parser
 


### PR DESCRIPTION
Currently output layer is hard coded to be initialized with scaled method. This PR supports optionally initializing it with normal distribution, using `--output-layer-init-method-normal` and `--output-layer-init-method-normal-std`.