### PR TITLE
Tokenizer - Add option to allow trust_remote_code for HuggingFace Tokenizer

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2259,6 +2259,8 @@ def _add_tokenizer_args(parser):
                        help='Number of special tokens in tiktoken tokenizer')
     group.add_argument('--tiktoken-special-tokens', type=str, nargs='+', default=None,
                        help='List of tiktoken special tokens, needs to have ["<unk>", "<s>", "</s>"]')
+    group.add_argument('--tokenizer-huggingface-trust-remote-code', action='store_true',
+                       help='Set trust_remote_code=True for HuggingFace tokenizer.')
     return parser
 
 

--- a/megatron/training/tokenizer/tokenizer.py
+++ b/megatron/training/tokenizer/tokenizer.py
@@ -46,6 +46,8 @@ def build_tokenizer(args, **kwargs):
         assert args.tokenizer_model is not None
         tokenizer = _GPTSentencePieceTokenizer(args.tokenizer_model)
     elif args.tokenizer_type == 'HuggingFaceTokenizer':
+        if args.tokenizer_huggingface_trust_remote_code:
+            kwargs['trust_remote_code'] = True
         tokenizer = _HuggingFaceTokenizer(args.tokenizer_model, **kwargs)
     elif args.tokenizer_type == 'Llama2Tokenizer':
         assert args.tokenizer_model is not None


### PR DESCRIPTION
Add `--tokenizer-huggingface-trust-remote-code` option to enable `trust_remote_code` for HuggingFace tokenizer. This allows executing code in customized tokenizer that is not in HuggingFace official repo.