### PR TITLE
Checkpoint - Support isolated checkpoint saving

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2010,6 +2010,8 @@ def _add_checkpointing_args(parser):
                        help='Path to the file which contains Azure blob SAS token for checkpoint upload.')
     group.add_argument('--ckpt-upload-blob-concurrency', type=str, default='AUTO',
                        help='Number of concurrent requests that can occur during Azure blob upload.')
+    group.add_argument('--ckpt-isolated-save', action='store_true',
+                       help='Whether the checkpoints need to be saved to multiple isolated places.')
     return parser
 
 

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -513,7 +513,7 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
 
     # And update the latest iteration
     if not torch.distributed.is_initialized() \
-            or torch.distributed.get_rank() == 0:
+            or torch.distributed.get_rank() == 0 or args.ckpt_isolated_save and args.local_rank == 0:
         tracker_filename = get_checkpoint_tracker_filename(save_dir)
 
         if ckpt_type == CheckpointType.LOCAL:
@@ -555,7 +555,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     if not torch.distributed.is_initialized() \
        or is_last_rank():
         def wandb_finalize_fn():
-            wandb_utils.on_save_checkpoint_success(checkpoint_name, get_checkpoint_tracker_filename(save_dir), save_dir, iteration)
+            if not args.ckpt_isolated_save:
+                wandb_utils.on_save_checkpoint_success(checkpoint_name, get_checkpoint_tracker_filename(save_dir), save_dir, iteration)
         if args.async_save:
             assert async_save_request is not None
             async_save_request.add_finalize_fn(wandb_finalize_fn)
@@ -1520,7 +1521,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, load_arg='load', 
     # Additional callback for wandb (last rank)
     if not torch.distributed.is_initialized() \
        or is_last_rank():
-        wandb_utils.on_load_checkpoint_success(checkpoint_name, load_dir)
+        if not args.ckpt_isolated_save:
+            wandb_utils.on_load_checkpoint_success(checkpoint_name, load_dir)
 
     torch.cuda.empty_cache()
 

--- a/megatron/training/utils.py
+++ b/megatron/training/utils.py
@@ -407,7 +407,7 @@ def append_to_progress_log(string, barrier=True):
     progress_log_filename = os.path.join(args.save, "progress.txt")
     if barrier:
         torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    if torch.distributed.get_rank() == 0 or args.ckpt_isolated_save and args.local_rank == 0:
         with open(progress_log_filename, 'a') as f:
             job_id = os.getenv('SLURM_JOB_ID', '')
             num_gpus = args.world_size


### PR DESCRIPTION
Add `--ckpt-isolated-save` option to support saving checkpoints to multiple isolated places.
Once enabled, it addresses two issues caused by unified storage assumption in vanilla Megatron-LM:
1) Checkpoint weights not found during wandb checkpoint tracking. Disable this since it requires last rank to see all weights which is not possible in isolated storage.
2) Checkpoint meta files not found during checkpointing. Force all nodes to save meta files.