### PR TITLE
Algorithm - Add Kaiming init option for MoE router weights

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from functools import partial
 from typing import Callable
 
+import math
 import torch
 
 from megatron.core import parallel_state
@@ -45,7 +46,10 @@ class Router(ABC, MegatronModule):
             torch.empty((self.config.num_moe_experts, self.config.hidden_size), dtype=torch.float32)
         )
         if config.perform_initialization:
-            config.init_method(self.weight)
+            if config.use_kaiming_init_for_moe_router:
+                torch.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+            else:
+                config.init_method(self.weight)
         self.weight.data = self.weight.data.to(dtype=config.params_dtype)
         setattr(self.weight, 'sequence_parallel', config.sequence_parallel)
         # If calculate per token loss, we need to scale up moe aux loss by the number of tokens.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -170,6 +170,9 @@ class TransformerConfig(ModelParallelConfig):
     training of very large models. This feature is only works when custom fsdp is turned on.
     """
 
+    use_kaiming_init_for_moe_router: bool = False
+    """Use Kaiming initialization for MoE router weights."""
+
     ####################
     # mixed-precision
     ####################

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1827,6 +1827,8 @@ def _add_initialization_args(parser):
     group.add_argument('--output-layer-init-method-normal-std', type=float, default=0.02,
                        help='Standard deviation of the zero mean normal '
                        'distribution used for weight initialization for output layers.')
+    group.add_argument('--use-kaiming-init-for-moe-router', action='store_true',
+                       help='Use Kaiming initialization for MoE router weights.')
 
     return parser
 


### PR DESCRIPTION
Adds `--use-kaiming-init-for-moe-router` to enable Kaiming init for MoE router weights.