### PR TITLE
MoE - Add option to use different score function for aux loss

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -128,6 +128,7 @@ class TopKRouter(Router):
         self.topk = self.config.moe_router_topk
         self.routing_type = self.config.moe_router_load_balancing_type
         self.score_function = self.config.moe_router_score_function
+        self.moe_aux_loss_score_function = self.config.moe_aux_loss_score_function
         self.input_jitter = None
 
         self.enable_expert_bias = self.config.moe_router_enable_expert_bias
@@ -197,9 +198,9 @@ class TopKRouter(Router):
         Returns:
             torch.Tensor: The normalized routing scores.
         """
-        if self.score_function == "softmax":
+        if self.moe_aux_loss_score_function == "softmax":
             scores = torch.softmax(logits, dim=-1, dtype=torch.float32)
-        elif self.score_function == "sigmoid":
+        elif self.moe_aux_loss_score_function == "sigmoid":
             scores = torch.sigmoid(logits)
             scores = (
                 scores / (scores.sum(dim=-1, keepdim=True) + 1e-20) if self.topk > 1 else scores

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -387,6 +387,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_router_score_function: str = "softmax"
     """Score function for MoE routing. Can be "softmax" or "sigmoid"."""
 
+    moe_aux_loss_score_function: str = "softmax"
+    """Score function for computing MoE aux loss. Can be "softmax" or "sigmoid"."""
+
     moe_router_dtype: Optional[str] = None
     """Data type for routing and expert output weighted averaging. Using fp32 or fp64 can
     improve stability especially when the number of experts is large (e.g. finegrained-moe).

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2553,6 +2553,10 @@ def _add_moe_args(parser):
                        choices=['softmax', 'sigmoid'],
                        default='softmax',
                        help='Score function for MoE TopK routing. Can be "softmax" or "sigmoid".')
+    group.add_argument('--moe-aux-loss-score-function', type=str,
+                       choices=['softmax', 'sigmoid'],
+                       default='softmax',
+                       help='Score function for computing MoE aux loss. Can be "softmax" or "sigmoid".')
     group.add_argument('--moe-router-topk', type=int, default=2,
                        help='Number of experts to route to for each token. The default is 2.')
     group.add_argument('--moe-router-pre-softmax', action='store_true',


### PR DESCRIPTION
Add option `--moe-aux-loss-score-function` to support using different functions in computing the MoE routing score and the MoE aux loss.