### PR TITLE
Parallelism - Enable interleaved-pp when layers in pp stage not divisible by vpp degree

### DIFF
--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -152,7 +152,9 @@ def get_num_layers_to_build(config: TransformerConfig) -> int:
             ), f"num_layers_per_pipeline_rank {num_layers_per_pipeline_rank} \
                 should be divisible by vp_size {vp_size}"
             num_layers_per_virtual_rank = num_layers_per_pipeline_rank // vp_size
+
             num_layers_to_build = num_layers_per_virtual_rank
+
     else:
         # Non-interleaved pipeline parallelism:
         # Each stage gets a contiguous set of layers.

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -132,12 +132,26 @@ def get_num_layers_to_build(config: TransformerConfig) -> int:
         # Stage 0: [0, 1]  [4, 5]
         # Stage 1: [2, 3]  [6, 7]
         vp_size = parallel_state.get_virtual_pipeline_model_parallel_world_size()
+        vp_rank = parallel_state.get_virtual_pipeline_model_parallel_rank()
 
-        assert (
-            num_layers_per_pipeline_rank % vp_size == 0
-        ), f"num_layers_per_pipeline_rank {num_layers_per_pipeline_rank} \
-            should be divisible by vp_size {vp_size}"
-        num_layers_per_virtual_rank = num_layers_per_pipeline_rank // vp_size
+        if (
+            config.num_layers_split_in_first_pipeline_stage is not None
+            and parallel_state.is_pipeline_first_stage(ignore_virtual=True)
+        ):
+            num_layers_per_virtual_rank = \
+                config.num_layers_split_in_first_pipeline_stage[vp_rank]
+        elif (
+            config.num_layers_split_in_last_pipeline_stage is not None
+            and parallel_state.is_pipeline_last_stage(ignore_virtual=True)
+        ):
+            num_layers_per_virtual_rank = \
+                config.num_layers_split_in_last_pipeline_stage[vp_rank]
+        else:
+            assert (
+                num_layers_per_pipeline_rank % vp_size == 0
+            ), f"num_layers_per_pipeline_rank {num_layers_per_pipeline_rank} \
+                should be divisible by vp_size {vp_size}"
+            num_layers_per_virtual_rank = num_layers_per_pipeline_rank // vp_size
 
         num_layers_to_build = num_layers_per_virtual_rank
 

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -138,13 +138,13 @@ def get_num_layers_to_build(config: TransformerConfig) -> int:
             config.num_layers_split_in_first_pipeline_stage is not None
             and parallel_state.is_pipeline_first_stage(ignore_virtual=True)
         ):
-            num_layers_per_virtual_rank = \
+            num_layers_to_build = \
                 config.num_layers_split_in_first_pipeline_stage[vp_rank]
         elif (
             config.num_layers_split_in_last_pipeline_stage is not None
             and parallel_state.is_pipeline_last_stage(ignore_virtual=True)
         ):
-            num_layers_per_virtual_rank = \
+            num_layers_to_build = \
                 config.num_layers_split_in_last_pipeline_stage[vp_rank]
         else:
             assert (
@@ -152,9 +152,7 @@ def get_num_layers_to_build(config: TransformerConfig) -> int:
             ), f"num_layers_per_pipeline_rank {num_layers_per_pipeline_rank} \
                 should be divisible by vp_size {vp_size}"
             num_layers_per_virtual_rank = num_layers_per_pipeline_rank // vp_size
-
-        num_layers_to_build = num_layers_per_virtual_rank
-
+            num_layers_to_build = num_layers_per_virtual_rank
     else:
         # Non-interleaved pipeline parallelism:
         # Each stage gets a contiguous set of layers.

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -135,17 +135,17 @@ def get_num_layers_to_build(config: TransformerConfig) -> int:
         vp_rank = parallel_state.get_virtual_pipeline_model_parallel_rank()
 
         if (
-            config.num_layers_split_in_first_pipeline_stage is not None
+            config.decoder_first_pipeline_num_layers_split is not None
             and parallel_state.is_pipeline_first_stage(ignore_virtual=True)
         ):
             num_layers_to_build = \
-                config.num_layers_split_in_first_pipeline_stage[vp_rank]
+                config.decoder_first_pipeline_num_layers_split[vp_rank]
         elif (
-            config.num_layers_split_in_last_pipeline_stage is not None
+            config.decoder_last_pipeline_num_layers_split is not None
             and parallel_state.is_pipeline_last_stage(ignore_virtual=True)
         ):
             num_layers_to_build = \
-                config.num_layers_split_in_last_pipeline_stage[vp_rank]
+                config.decoder_last_pipeline_num_layers_split[vp_rank]
         else:
             assert (
                 num_layers_per_pipeline_rank % vp_size == 0

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -552,6 +552,9 @@ class TransformerConfig(ModelParallelConfig):
     mamba_num_groups: int = 8
     """The number of groups used in Mamba layers."""
 
+    heterogeneous_block_specs: bool = False
+    """Whether to use heterogeneous block specs (nemotron-nas architecture)."""
+
     def _is_split_valid(self, stage, layers_split, num_layers, vp_size):
         if not isinstance(layers_split, list):
             raise ValueError(
@@ -576,9 +579,6 @@ class TransformerConfig(ModelParallelConfig):
                 f'decoder_{stage}_pipeline_num_layers={num_layers}'
             )
         return True
-
-    heterogeneous_block_specs: bool = False
-    """Whether to use heterogeneous block specs (nemotron-nas architecture)."""
 
     def _split_pipeline_stage(self, stage, num_layers, vp_size):
         quotient = num_layers // vp_size

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -552,17 +552,46 @@ class TransformerConfig(ModelParallelConfig):
     mamba_num_groups: int = 8
     """The number of groups used in Mamba layers."""
 
+    def is_split_valid(self, stage, layers_split, num_layers, vp_size):
+        if not isinstance(layers_split, list):
+            raise ValueError(
+                f'decoder_{stage}_pipeline_num_layers_split={layers_split} '
+                f'should be a list'
+            )
+        if len(layers_split) != vp_size:
+            raise ValueError(
+                f'the size of the list decoder_{stage}_pipeline_num_'
+                f'layers_split={layers_split} should be equal to '
+                f'virtual_pipeline_model_parallel_size={vp_size}'
+            )
+        if not all(x > 0 for x in layers_split):
+            raise ValueError(
+                f'layer numbers in decoder_{stage}_pipeline_num_layers_split='
+                f'{layers_split} should all be larger than 0'
+            )
+        if sum(layers_split) != num_layers:
+            raise ValueError(
+                f'the sum of decoder_{stage}_pipeline_num_'
+                f'layers_split={layers_split} should be equal to '
+                f'decoder_{stage}_pipeline_num_layers={num_layers}'
+            )
+        print(
+            f'the virtual pipeline split of the {stage} pipeline '
+            f'stage is provided by user: {layers_split}'
+        )
+        return True
+
     heterogeneous_block_specs: bool = False
     """Whether to use heterogeneous block specs (nemotron-nas architecture)."""
 
     def split_pipeline_stage(self, stage, num_layers, vp_size):
         quotient = num_layers // vp_size
-        residue = num_layers % vp_size
+        remainder = num_layers % vp_size
         num_layers_split = [
-            quotient + 1 if i < residue else quotient for i in range(vp_size)
+            quotient + 1 if i < remainder else quotient for i in range(vp_size)
         ]
         print(
-            f'number of layers at the {stage} stage {num_layers} '
+            f'number of layers at the {stage} pipeline stage {num_layers} '
             f'is not divisible by virtual pipeline parallel degree {vp_size}, '
             f'thus splitting the {stage} stage as {num_layers_split}'
         )
@@ -820,12 +849,24 @@ class TransformerConfig(ModelParallelConfig):
                         % self.virtual_pipeline_model_parallel_size
                         != 0
                     ):
-                        self.num_layers_split_in_first_pipeline_stage = \
-                            self.split_pipeline_stage(
+                        if self.num_layers_split_in_first_pipeline_stage is not None:
+                            if not self.is_split_valid(
                                 'first',
+                                self.num_layers_split_in_first_pipeline_stage,
                                 self.num_layers_in_first_pipeline_stage,
                                 self.virtual_pipeline_model_parallel_size
-                            )
+                            ):
+                                raise ValueError(
+                                    f'Invalid decoder_first_pipeline_num_layers_split: '
+                                    f'{self.num_layers_split_in_first_pipeline_stage}'
+                                )
+                        else:
+                            self.num_layers_split_in_first_pipeline_stage = \
+                                self.split_pipeline_stage(
+                                    'first',
+                                    self.num_layers_in_first_pipeline_stage,
+                                    self.virtual_pipeline_model_parallel_size
+                                )
                 num_layers -= self.num_layers_in_first_pipeline_stage
                 pipeline_parallel_size -= 1
 
@@ -839,12 +880,24 @@ class TransformerConfig(ModelParallelConfig):
                         % self.virtual_pipeline_model_parallel_size
                         != 0
                     ):
-                        self.num_layers_split_in_last_pipeline_stage = \
-                            self.split_pipeline_stage(
+                        if self.num_layers_split_in_last_pipeline_stage is not None:
+                            if not self.is_split_valid(
                                 'last',
+                                self.num_layers_split_in_last_pipeline_stage,
                                 self.num_layers_in_last_pipeline_stage,
                                 self.virtual_pipeline_model_parallel_size
-                            )
+                            ):
+                                raise ValueError(
+                                    f'Invalid decoder_last_pipeline_num_layers_split: '
+                                    f'{self.num_layers_split_in_last_pipeline_stage}'
+                                )
+                        else:
+                            self.num_layers_split_in_last_pipeline_stage = \
+                                self.split_pipeline_stage(
+                                    'last',
+                                    self.num_layers_in_last_pipeline_stage,
+                                    self.virtual_pipeline_model_parallel_size
+                                )
                 num_layers -= self.num_layers_in_last_pipeline_stage
                 pipeline_parallel_size -= 1
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -47,13 +47,13 @@ class TransformerConfig(ModelParallelConfig):
     """List of transformer layers split on first pipeline stage,
     when num_layers_in_first_pipeline_stage is not divisible by
     virtual_pipeline_model_parallel_size.
-    None implies equal layer division ont first pipeline stage."""
+    None implies equal layer division on first pipeline stage."""
 
     num_layers_split_in_last_pipeline_stage: Optional[list] = None
     """List of transformer layers split on last pipeline stage,
     when num_layers_in_last_pipeline_stage is not divisible by
     virtual_pipeline_model_parallel_size.
-    None implies equal layer division ont last pipeline stage."""
+    None implies equal layer division on last pipeline stage."""
 
     account_for_embedding_in_pipeline_split: bool = False
     """If set, the embedding layer will be treated as a standard transformer

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -43,13 +43,13 @@ class TransformerConfig(ModelParallelConfig):
     """Number of transformer layers on last pipeline stage.
     None implies equal layer division across PP ranks."""
 
-    num_layers_split_in_first_pipeline_stage: Optional[list] = None
+    decoder_first_pipeline_num_layers_split: Optional[list] = None
     """List of transformer layers split on first pipeline stage,
     when num_layers_in_first_pipeline_stage is not divisible by
     virtual_pipeline_model_parallel_size.
     None implies equal layer division on first pipeline stage."""
 
-    num_layers_split_in_last_pipeline_stage: Optional[list] = None
+    decoder_last_pipeline_num_layers_split: Optional[list] = None
     """List of transformer layers split on last pipeline stage,
     when num_layers_in_last_pipeline_stage is not divisible by
     virtual_pipeline_model_parallel_size.
@@ -552,7 +552,7 @@ class TransformerConfig(ModelParallelConfig):
     mamba_num_groups: int = 8
     """The number of groups used in Mamba layers."""
 
-    def is_split_valid(self, stage, layers_split, num_layers, vp_size):
+    def _is_split_valid(self, stage, layers_split, num_layers, vp_size):
         if not isinstance(layers_split, list):
             raise ValueError(
                 f'decoder_{stage}_pipeline_num_layers_split={layers_split} '
@@ -575,24 +575,23 @@ class TransformerConfig(ModelParallelConfig):
                 f'layers_split={layers_split} should be equal to '
                 f'decoder_{stage}_pipeline_num_layers={num_layers}'
             )
-        print(
-            f'the virtual pipeline split of the {stage} pipeline '
-            f'stage is provided by user: {layers_split}'
-        )
         return True
 
     heterogeneous_block_specs: bool = False
     """Whether to use heterogeneous block specs (nemotron-nas architecture)."""
 
-    def split_pipeline_stage(self, stage, num_layers, vp_size):
+    def _split_pipeline_stage(self, stage, num_layers, vp_size):
         quotient = num_layers // vp_size
         remainder = num_layers % vp_size
         num_layers_split = [
             quotient + 1 if i < remainder else quotient for i in range(vp_size)
         ]
-        print(
+
+        from megatron.training import print_rank_0  # To prevent circular import.
+        print_rank_0(
             f'number of layers at the {stage} pipeline stage {num_layers} '
             f'is not divisible by virtual pipeline parallel degree {vp_size}, '
+            f'and the {stage} stage split list is not configured by user, '
             f'thus splitting the {stage} stage as {num_layers_split}'
         )
         return num_layers_split    
@@ -849,24 +848,23 @@ class TransformerConfig(ModelParallelConfig):
                         % self.virtual_pipeline_model_parallel_size
                         != 0
                     ):
-                        if self.num_layers_split_in_first_pipeline_stage is not None:
-                            if not self.is_split_valid(
-                                'first',
-                                self.num_layers_split_in_first_pipeline_stage,
-                                self.num_layers_in_first_pipeline_stage,
-                                self.virtual_pipeline_model_parallel_size
-                            ):
-                                raise ValueError(
-                                    f'Invalid decoder_first_pipeline_num_layers_split: '
-                                    f'{self.num_layers_split_in_first_pipeline_stage}'
-                                )
-                        else:
-                            self.num_layers_split_in_first_pipeline_stage = \
-                                self.split_pipeline_stage(
+                        if self.decoder_first_pipeline_num_layers_split is None:
+                            self.decoder_first_pipeline_num_layers_split = \
+                                self._split_pipeline_stage(
                                     'first',
                                     self.num_layers_in_first_pipeline_stage,
                                     self.virtual_pipeline_model_parallel_size
                                 )
+                        if not self._is_split_valid(
+                            'first',
+                            self.decoder_first_pipeline_num_layers_split,
+                            self.num_layers_in_first_pipeline_stage,
+                            self.virtual_pipeline_model_parallel_size
+                        ):
+                            raise ValueError(
+                                f'Invalid decoder_first_pipeline_num_layers_split: '
+                                f'{self.decoder_first_pipeline_num_layers_split}'
+                            )
                 num_layers -= self.num_layers_in_first_pipeline_stage
                 pipeline_parallel_size -= 1
 
@@ -880,24 +878,23 @@ class TransformerConfig(ModelParallelConfig):
                         % self.virtual_pipeline_model_parallel_size
                         != 0
                     ):
-                        if self.num_layers_split_in_last_pipeline_stage is not None:
-                            if not self.is_split_valid(
-                                'last',
-                                self.num_layers_split_in_last_pipeline_stage,
-                                self.num_layers_in_last_pipeline_stage,
-                                self.virtual_pipeline_model_parallel_size
-                            ):
-                                raise ValueError(
-                                    f'Invalid decoder_last_pipeline_num_layers_split: '
-                                    f'{self.num_layers_split_in_last_pipeline_stage}'
-                                )
-                        else:
-                            self.num_layers_split_in_last_pipeline_stage = \
-                                self.split_pipeline_stage(
+                        if self.decoder_last_pipeline_num_layers_split is None:
+                            self.decoder_last_pipeline_num_layers_split = \
+                                self._split_pipeline_stage(
                                     'last',
                                     self.num_layers_in_last_pipeline_stage,
                                     self.virtual_pipeline_model_parallel_size
                                 )
+                        if not self._is_split_valid(
+                            'last',
+                            self.decoder_last_pipeline_num_layers_split,
+                            self.num_layers_in_last_pipeline_stage,
+                            self.virtual_pipeline_model_parallel_size
+                        ):
+                            raise ValueError(
+                                f'Invalid decoder_last_pipeline_num_layers_split: '
+                                f'{self.decoder_last_pipeline_num_layers_split}'
+                            )
                 num_layers -= self.num_layers_in_last_pipeline_stage
                 pipeline_parallel_size -= 1
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -43,6 +43,18 @@ class TransformerConfig(ModelParallelConfig):
     """Number of transformer layers on last pipeline stage.
     None implies equal layer division across PP ranks."""
 
+    num_layers_split_in_first_pipeline_stage: Optional[list] = None
+    """List of transformer layers split on first pipeline stage,
+    when num_layers_in_first_pipeline_stage is not divisible by
+    virtual_pipeline_model_parallel_size.
+    None implies equal layer division ont first pipeline stage."""
+
+    num_layers_split_in_last_pipeline_stage: Optional[list] = None
+    """List of transformer layers split on last pipeline stage,
+    when num_layers_in_last_pipeline_stage is not divisible by
+    virtual_pipeline_model_parallel_size.
+    None implies equal layer division ont last pipeline stage."""
+
     account_for_embedding_in_pipeline_split: bool = False
     """If set, the embedding layer will be treated as a standard transformer
     layer in the context of partition and placement for pipeline parallelism."""
@@ -543,6 +555,19 @@ class TransformerConfig(ModelParallelConfig):
     heterogeneous_block_specs: bool = False
     """Whether to use heterogeneous block specs (nemotron-nas architecture)."""
 
+    def split_pipeline_stage(self, stage, num_layers, vp_size):
+        quotient = num_layers // vp_size
+        residue = num_layers % vp_size
+        num_layers_split = [
+            quotient + 1 if i < residue else quotient for i in range(vp_size)
+        ]
+        print(
+            f'number of layers at the {stage} stage {num_layers} '
+            f'is not divisible by virtual pipeline parallel degree {vp_size}, '
+            f'thus splitting the {stage} stage as {num_layers_split}'
+        )
+        return num_layers_split    
+
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.
         See https://docs.python.org/3/library/dataclasses.html#post-init-processing for more
@@ -795,12 +820,12 @@ class TransformerConfig(ModelParallelConfig):
                         % self.virtual_pipeline_model_parallel_size
                         != 0
                     ):
-                        raise ValueError(
-                            f'number of layers at first stage: '
-                            f'{self.num_layers_in_first_pipeline_stage}'
-                            f'must be divisible by virtual pipeline'
-                            f'parallel degree {self.virtual_pipeline_model_parallel_size}'
-                        )
+                        self.num_layers_split_in_first_pipeline_stage = \
+                            self.split_pipeline_stage(
+                                'first',
+                                self.num_layers_in_first_pipeline_stage,
+                                self.virtual_pipeline_model_parallel_size
+                            )
                 num_layers -= self.num_layers_in_first_pipeline_stage
                 pipeline_parallel_size -= 1
 
@@ -814,12 +839,12 @@ class TransformerConfig(ModelParallelConfig):
                         % self.virtual_pipeline_model_parallel_size
                         != 0
                     ):
-                        raise ValueError(
-                            f'number of layers at last stage: '
-                            f'{self.num_layers_in_last_pipeline_stage}'
-                            f'must be divisible by virtual pipeline'
-                            f'parallel degree {self.virtual_pipeline_model_parallel_size}'
-                        )
+                        self.num_layers_split_in_last_pipeline_stage = \
+                            self.split_pipeline_stage(
+                                'last',
+                                self.num_layers_in_last_pipeline_stage,
+                                self.virtual_pipeline_model_parallel_size
+                            )
                 num_layers -= self.num_layers_in_last_pipeline_stage
                 pipeline_parallel_size -= 1
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -104,19 +104,21 @@ def get_transformer_layer_offset(config: TransformerConfig):
                     config.num_layers_split_in_first_pipeline_stage is not None
                     or config.num_layers_split_in_last_pipeline_stage is not None
                 ):
-                    first_stage_split = [
-                        num_layers_per_virtual_model_chunk_in_first_pipeline_stage
-                        for _ in range(vp_size)
-                    ]
                     if config.num_layers_split_in_first_pipeline_stage is not None:
                         first_stage_split = config.num_layers_split_in_first_pipeline_stage
+                    else:
+                        first_stage_split = [
+                            num_layers_per_virtual_model_chunk_in_first_pipeline_stage
+                            for _ in range(vp_size)
+                        ]
 
-                    last_stage_split = [
-                        num_layers_per_virtual_model_chunk_in_last_pipeline_stage
-                        for _ in range(vp_size)
-                    ]
                     if config.num_layers_split_in_last_pipeline_stage is not None:
-                        last_stage_split = config.num_layers_split_in_last_pipeline_stage        
+                        last_stage_split = config.num_layers_split_in_last_pipeline_stage
+                    else:
+                        last_stage_split = [
+                            num_layers_per_virtual_model_chunk_in_last_pipeline_stage
+                            for _ in range(vp_size)
+                        ]
 
                     middle_chunk_layers = (
                         num_layers_per_vritual_model_chunk_in_middle_pipeline_stage
@@ -125,18 +127,18 @@ def get_transformer_layer_offset(config: TransformerConfig):
 
                     pipeline_size = parallel_state.get_pipeline_model_parallel_world_size()
                     offset = 0
-                    for i in range(vp_rank):
-                        for j in range(pipeline_size):
-                            if j == 0:
-                                offset += first_stage_split[i]
-                            elif j == pipeline_size - 1:
-                                offset += last_stage_split[i]
+                    for vp_idx in range(vp_rank):
+                        for pp_idx in range(pipeline_size):
+                            if pp_idx == 0:
+                                offset += first_stage_split[vp_idx]
+                            elif pp_idx == pipeline_size - 1:
+                                offset += last_stage_split[vp_idx]
                             else:
                                 offset += middle_chunk_layers
-                    for k in range(pipeline_rank):
-                        if k == 0:
+                    for pp_idx in range(pipeline_rank):
+                        if pp_idx == 0:
                             offset += first_stage_split[vp_rank]
-                        elif k == pipeline_size - 1:
+                        elif pp_idx == pipeline_size - 1:
                             offset += last_stage_split[vp_rank]
                         else:
                             offset += middle_chunk_layers

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -101,19 +101,19 @@ def get_transformer_layer_offset(config: TransformerConfig):
                 )
 
                 if (
-                    config.num_layers_split_in_first_pipeline_stage is not None
-                    or config.num_layers_split_in_last_pipeline_stage is not None
+                    config.decoder_first_pipeline_num_layers_split is not None
+                    or config.decoder_last_pipeline_num_layers_split is not None
                 ):
-                    if config.num_layers_split_in_first_pipeline_stage is not None:
-                        first_stage_split = config.num_layers_split_in_first_pipeline_stage
+                    if config.decoder_first_pipeline_num_layers_split is not None:
+                        first_stage_split = config.decoder_first_pipeline_num_layers_split
                     else:
                         first_stage_split = [
                             num_layers_per_virtual_model_chunk_in_first_pipeline_stage
                             for _ in range(vp_size)
                         ]
 
-                    if config.num_layers_split_in_last_pipeline_stage is not None:
-                        last_stage_split = config.num_layers_split_in_last_pipeline_stage
+                    if config.decoder_last_pipeline_num_layers_split is not None:
+                        last_stage_split = config.decoder_last_pipeline_num_layers_split
                     else:
                         last_stage_split = [
                             num_layers_per_virtual_model_chunk_in_last_pipeline_stage

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -100,19 +100,60 @@ def get_transformer_layer_offset(config: TransformerConfig):
                     + num_layers_per_virtual_model_chunk_in_last_pipeline_stage
                 )
 
-                # Calculate the layer offset with interleaved uneven pipeline parallelism
-                if pipeline_rank == 0:
-                    offset = vp_rank * total_virtual_chunks
-                else:
-                    offset = (
-                        vp_rank * total_virtual_chunks
-                        + num_layers_per_virtual_model_chunk_in_first_pipeline_stage
-                        + (pipeline_rank - 1)
-                        * (
-                            num_layers_per_vritual_model_chunk_in_middle_pipeline_stage
-                            // middle_pipeline_stages
-                        )
+                if (
+                    config.num_layers_split_in_first_pipeline_stage is not None
+                    or config.num_layers_split_in_last_pipeline_stage is not None
+                ):
+                    first_stage_split = [
+                        num_layers_per_virtual_model_chunk_in_first_pipeline_stage
+                        for _ in range(vp_size)
+                    ]
+                    if config.num_layers_split_in_first_pipeline_stage is not None:
+                        first_stage_split = config.num_layers_split_in_first_pipeline_stage
+
+                    last_stage_split = [
+                        num_layers_per_virtual_model_chunk_in_last_pipeline_stage
+                        for _ in range(vp_size)
+                    ]
+                    if config.num_layers_split_in_last_pipeline_stage is not None:
+                        last_stage_split = config.num_layers_split_in_last_pipeline_stage        
+
+                    middle_chunk_layers = (
+                        num_layers_per_vritual_model_chunk_in_middle_pipeline_stage
+                        // middle_pipeline_stages
                     )
+
+                    pipeline_size = parallel_state.get_pipeline_model_parallel_world_size()
+                    offset = 0
+                    for i in range(vp_rank):
+                        for j in range(pipeline_size):
+                            if j == 0:
+                                offset += first_stage_split[i]
+                            elif j == pipeline_size - 1:
+                                offset += last_stage_split[i]
+                            else:
+                                offset += middle_chunk_layers
+                    for k in range(pipeline_rank):
+                        if k == 0:
+                            offset += first_stage_split[vp_rank]
+                        elif k == pipeline_size - 1:
+                            offset += last_stage_split[vp_rank]
+                        else:
+                            offset += middle_chunk_layers
+                else:
+                    # Calculate the layer offset with interleaved uneven pipeline parallelism
+                    if pipeline_rank == 0:
+                        offset = vp_rank * total_virtual_chunks
+                    else:
+                        offset = (
+                            vp_rank * total_virtual_chunks
+                            + num_layers_per_virtual_model_chunk_in_first_pipeline_stage
+                            + (pipeline_rank - 1)
+                            * (
+                                num_layers_per_vritual_model_chunk_in_middle_pipeline_stage
+                                // middle_pipeline_stages
+                            )
+                        )
             else:
                 if middle_pipeline_stages > 0:
                     num_layers_per_pipeline_rank = middle_num_layers // middle_pipeline_stages

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -246,9 +246,6 @@ def load_retro_args(args):
     args.retro_bert_tokenizer_type = retro_config.retro_bert_tokenizer_type
     args.retro_bert_vocab_file = retro_config.retro_bert_vocab_file
 
-def list_of_ints(list_str):
-    return list(map(int, list_str.split(',')))
-
 def moe_freq_type(x):
     """Frequency between MoE layers and Dense layers.
 
@@ -1021,8 +1018,6 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['rotary_interleaved'] = args.rotary_interleaved
     kw_args['num_layers_in_first_pipeline_stage']= args.decoder_first_pipeline_num_layers
     kw_args['num_layers_in_last_pipeline_stage']= args.decoder_last_pipeline_num_layers
-    kw_args['num_layers_split_in_first_pipeline_stage'] = args.decoder_first_pipeline_num_layers_split
-    kw_args['num_layers_split_in_last_pipeline_stage'] = args.decoder_last_pipeline_num_layers_split
     kw_args['fp8_param'] = args.fp8_param_gather
     if args.swiglu:
         kw_args['activation_func'] = F.silu
@@ -2062,11 +2057,11 @@ def _add_distributed_args(parser):
                        help=('The number of transformer layers on the last pipeline stage of the decoder. '
                        'Default None is even split of transformer layers across all pipeline stages'))
     group.add_argument('--decoder-first-pipeline-num-layers-split',
-                       type=list_of_ints, default=None,
-                       help=('Virtual pipeline split in uneven pipeline mode of the first stage.'))
+                       nargs='+', type=int, default=None,
+                       help=('Virtual pipeline split of the first stage in uneven pipeline mode.'))
     group.add_argument('--decoder-last-pipeline-num-layers-split',
-                       type=list_of_ints, default=None,
-                       help=('Virtual pipeline split in uneven pipeline mode of the last stage.'))
+                       nargs='+', type=int, default=None,
+                       help=('Virtual pipeline split of the last stage in uneven pipeline mode.'))
     group.add_argument('--model-parallel-size', type=int, default=None,
                        help='Old model parallel argument, do not use. Use '
                        '--tensor-model-parallel-size instead.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -246,6 +246,9 @@ def load_retro_args(args):
     args.retro_bert_tokenizer_type = retro_config.retro_bert_tokenizer_type
     args.retro_bert_vocab_file = retro_config.retro_bert_vocab_file
 
+def list_of_ints(list_str):
+    return list(map(int, list_str.split(',')))
+
 def moe_freq_type(x):
     """Frequency between MoE layers and Dense layers.
 
@@ -1018,6 +1021,8 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['rotary_interleaved'] = args.rotary_interleaved
     kw_args['num_layers_in_first_pipeline_stage']= args.decoder_first_pipeline_num_layers
     kw_args['num_layers_in_last_pipeline_stage']= args.decoder_last_pipeline_num_layers
+    kw_args['num_layers_split_in_first_pipeline_stage'] = args.decoder_first_pipeline_num_layers_split
+    kw_args['num_layers_split_in_last_pipeline_stage'] = args.decoder_last_pipeline_num_layers_split
     kw_args['fp8_param'] = args.fp8_param_gather
     if args.swiglu:
         kw_args['activation_func'] = F.silu
@@ -2056,6 +2061,12 @@ def _add_distributed_args(parser):
                        type=int, default=None,
                        help=('The number of transformer layers on the last pipeline stage of the decoder. '
                        'Default None is even split of transformer layers across all pipeline stages'))
+    group.add_argument('--decoder-first-pipeline-num-layers-split',
+                       type=list_of_ints, default=None,
+                       help=('Virtual pipeline split in uneven pipeline mode of the first stage.'))
+    group.add_argument('--decoder-last-pipeline-num-layers-split',
+                       type=list_of_ints, default=None,
+                       help=('Virtual pipeline split in uneven pipeline mode of the last stage.'))
     group.add_argument('--model-parallel-size', type=int, default=None,
                        help='Old model parallel argument, do not use. Use '
                        '--tensor-model-parallel-size instead.')

--- a/tests/unit_tests/transformer/test_transformer_block.py
+++ b/tests/unit_tests/transformer/test_transformer_block.py
@@ -140,43 +140,65 @@ class TestPipelineParallelTransformerBlock:
     @pytest.mark.parametrize(
         "num_layers, pipeline_model_parallel_size, virtual_pipeline_model_parallel_size, "
         "account_for_embedding_in_pipeline_split, account_for_loss_in_pipeline_split, "
-        "first_pipeline_num_layers, last_pipeline_num_layers, should_assert_error",
+        "first_pipeline_num_layers, last_pipeline_num_layers, first_pipeline_num_layers_split, "
+        "last_pipeline_num_layers_split, should_assert_error",
         [
             # Last pipeline stage has specified layers
-            (60, 5, None, False, False, None, 4, False),
+            (60, 5, None, False, False, None, 4, None, None, False),
             # Uneven PP 6*[8]+[6]+[6]=60
-            (60, 8, None, False, False, 6, 6, False),
+            (60, 8, None, False, False, 6, 6, None, None, False),
             # Even PP
-            (64, 4, None, False, False, None, None, False),
+            (64, 4, None, False, False, None, None, None, None, False),
             # Even VPP
-            (64, 4, 8, False, False, None, None, False),
+            (64, 4, 8, False, False, None, None, None, None, False),
             # First pipeline stage has specified layers
             # Should distribute remaining layers evenly among other stages
-            (60, 6, None, False, False, 5, None, False),
+            (60, 6, None, False, False, 5, None, None, None, False),
             # Uneven distribution leading to assertion error
-            (101, 8, None, False, False, 13, 13, True),
+            (101, 8, None, False, False, 13, 13, None, None, True),
             # Include embedding in pipeline split without virtual PP
-            (63, 4, None, True, False, None, None, False),
+            (63, 4, None, True, False, None, None, None, None, False),
             # Include loss in pipeline split without virtual PP
-            (63, 4, None, False, True, None, None, False),
+            (63, 4, None, False, True, None, None, None, None, False),
             # Include embedding and loss in pipeline split without virtual PP
-            (62, 4, None, True, True, None, None, False),
+            (62, 4, None, True, True, None, None, None, None, False),
             # Include embedding and loss with virtual PP
-            (62, 4, 2, True, True, None, None, False),
+            (62, 4, 2, True, True, None, None, None, None, False),
             # num_layers not divisible by pipeline size without embedding/loss
-            (65, 4, None, False, False, None, None, True),
+            (65, 4, None, False, False, None, None, None, None, True),
             # num_layers not divisible by pipeline size with embedding/loss
-            (65, 4, None, True, True, None, None, True),
+            (65, 4, None, True, True, None, None, None, None, True),
             # Uneven distribution with specified first pipeline layers causing error
-            (61, 4, None, False, False, 12, None, True),
+            (61, 4, None, False, False, 12, None, None, None, True),
             # Too few layers for the number of pipeline stages
-            (2, 4, None, False, False, None, None, True),
+            (2, 4, None, False, False, None, None, None, None, True),
             # Uneven PP with embedding included (should assert per code)
-            (60, 6, None, True, False, 5, 5, True),
+            (60, 6, None, True, False, 5, 5, None, None, True),
             # Virtual PP where num_layers not divisible by total virtual stages
-            (50, 2, 7, False, False, None, None, True),
+            (50, 2, 7, False, False, None, None, None, None, True),
             # Edge case where num_layers per virtual rank is zero
-            (4, 4, 4, False, False, None, None, True),
+            (4, 4, 4, False, False, None, None, None, None, True),
+            # Auto first/last stage split
+            (64, 8, 2, False, False, 9, 7, None, None, False),
+            (64, 8, 4, False, False, 10, 6, None, None, False),
+            (64, 8, 4, False, False, 13, 3, None, None, True),
+            (64, 8, 2, True, False, 9, 7, None, None, True),
+            (64, 8, 2, False, True, 9, 7, None, None, True),
+            (64, 8, 2, True, True, 9, 7, None, None, True),
+            # Manual first/last stage split
+            (64, 8, 4, False, False, 9, 7, [2, 2, 2, 3], [2, 2, 2, 1], False),
+            (64, 8, 2, False, False, 9, 7, [5, 4], [4, 3], False),
+            (64, 8, 2, True, False, 9, 7, [5, 4], [4, 3], True),
+            (64, 8, 2, False, True, 9, 7, [5, 4], [4, 3], True),
+            (64, 8, 2, True, True, 9, 7, [5, 4], [4, 3], True),
+            (64, 8, 2, False, False, 9, 7, [3, 3, 3], [4, 3], True),
+            (64, 8, 2, False, False, 9, 7, [5, 4], [2, 3, 2], True),
+            (64, 8, 2, False, False, 9, 7, [-1, 10], [4, 3], True),
+            (64, 8, 2, False, False, 9, 7, [5, 4], [9, -2], True),
+            (64, 8, 2, False, False, 9, 7, [0, 9], [4, 3], True),
+            (64, 8, 2, False, False, 9, 7, [5, 4], [7, 0], True),
+            (64, 8, 2, False, False, 9, 7, [5, 5], [4, 3], True),
+            (64, 8, 2, False, False, 9, 7, [5, 4], [4, 4], True),
         ],
     )
     def test_layer_builder(
@@ -188,6 +210,8 @@ class TestPipelineParallelTransformerBlock:
         account_for_loss_in_pipeline_split,
         first_pipeline_num_layers,
         last_pipeline_num_layers,
+        first_pipeline_num_layers_split,
+        last_pipeline_num_layers_split,
         should_assert_error,
     ):
         Utils.fake_initialize_model_parallel(
@@ -207,6 +231,8 @@ class TestPipelineParallelTransformerBlock:
                 account_for_loss_in_pipeline_split=account_for_loss_in_pipeline_split,
                 num_layers_in_first_pipeline_stage=first_pipeline_num_layers,
                 num_layers_in_last_pipeline_stage=last_pipeline_num_layers,
+                decoder_first_pipeline_num_layers_split=first_pipeline_num_layers_split,
+                decoder_last_pipeline_num_layers_split=last_pipeline_num_layers_split,
                 pipeline_dtype=torch.bfloat16,
                 hidden_size=128,
                 num_attention_heads=16,


### PR DESCRIPTION
**Functionality** 
- Enable interleaved-pp when layers in the first/last pp stage are not divisible by vpp degree with configurable `--decoder-first-pipeline-num-layers-split` and `--decoder-last-pipeline-num-layers-split`
  - Auto split: `layers-9887, pp-4, vpp-2` ==> `[5, 4], [4, 4], [4, 4], [4, 3]`
  - Custom split: `layers-9887, pp-4, vpp-2, --decoder-first-pipeline-num-layers-split=[4, 5], --decoder-last-pipeline-num-layers-split=[3, 4] ` ==> `[4, 5], [4, 4], [4, 4], [3, 4]`

 **Performance**
- Achieve nearly linear combination of the throughput gain of both interleaved-pp and uneven-pp while keeping the same accuracy
