### PR TITLE
Checkpoint - Disable non-blocking when saving dist checkpoint in AMD GPUs

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -174,7 +174,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         transform_list = [self.transforms] if hasattr(self, 'transforms') else []
         return (
             partial(self.write_preloaded_data_multiproc, transform_list),
-            partial(self.preload_tensors, self.write_buckets, True),
+            partial(self.preload_tensors, self.write_buckets, bool(not torch.version.hip)),
             [torch.distributed.get_rank(), self.write_buckets, self.results_queue],
         )
 


### PR DESCRIPTION
Workaround hang issue when saving dist checkpoint on ROCm platform.

Because `non_blocking=True` will use pin memory on ROCm, which will lead to segmentation fault in the forked subprocess, use `non_blocking=False` in dist checkpoint saving subprocess to workaround this issue.