### PR TITLE
Logging - Add per-layer grad norm logs

### DIFF
--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -273,7 +273,7 @@ class MegatronOptimizer(ABC):
             if isinstance(global_layer_id, str):
                 for idx, pattern in enumerate(extra_patterns):
                     if pattern in global_layer_id:
-                        total_norm_per_layer[num_layers + idx] = total_norm
+                        total_norm_per_layer[num_layers + idx] += total_norm
                         break
             else:
                 total_norm_per_layer[global_layer_id] = total_norm

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -11,9 +11,6 @@ from logging import getLogger
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
-from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
-from megatron.training import get_args
-from megatron.training.arguments import core_transformer_config_from_args
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_scale
@@ -156,17 +153,13 @@ class MegatronOptimizer(ABC):
 
         return grads_for_norm
 
-    def get_main_grads_for_grad_norm_per_layer(self) -> Dict[Union[int, str], List[torch.Tensor]]:
+    def get_main_grads_for_grad_norm_per_layer(self, global_layer_offset) -> Dict[Union[int, str], List[torch.Tensor]]:
         """
         Get per-layer main_grads that should be taken into account to compute the grad norm.
         Currently only support DistributedDataParallel (DDP).
         """
         if not hasattr(self, 'grads_for_norm_per_layer'):
             self.grads_for_norm_per_layer = {}
-
-            args = get_args()
-            transformer_config = core_transformer_config_from_args(args)
-            global_layer_offset = get_transformer_layer_offset(transformer_config)
 
             if isinstance(self, ChainedOptimizer):
                 model_chunks = self.model_chunks
@@ -199,9 +192,26 @@ class MegatronOptimizer(ABC):
                             if param in buffer.param_to_bucket:
                                 bucket = buffer.param_to_bucket[param]
                                 grad_data = bucket.grad_data
-                                param_start_index, param_end_index, _ = buffer.param_index_map[param]
-                                grad = grad_data[param_start_index - bucket.offset : param_end_index - bucket.offset]
-                                self.grads_for_norm_per_layer[global_layer_id].append(grad)
+
+                                # Find the intersection of DDP optimizer grad buffer's local shard and parameter's grad buffer
+                                assert grad_data.numel() % buffer.data_parallel_world_size == 0
+                                grad_shard_size = grad_data.numel() // buffer.data_parallel_world_size
+                                grad_shard_rank = torch.distributed.get_rank(group=buffer.data_parallel_group)
+                                grad_shard_range = [grad_shard_rank * grad_shard_size, (grad_shard_rank + 1) * grad_shard_size]
+
+                                param_grad_start_index, param_grad_end_index, _ = buffer.param_index_map[param]
+                                param_grad_range = [param_grad_start_index - bucket.offset, param_grad_end_index - bucket.offset]
+
+                                reduced_param_grad_range = [
+                                    max(grad_shard_range[0], param_grad_range[0]),
+                                    min(grad_shard_range[1], param_grad_range[1]),
+                                ]
+
+                                # Only append non-empty grad buffer
+                                if reduced_param_grad_range[0] < reduced_param_grad_range[1]:
+                                    grad = grad_data[reduced_param_grad_range[0] : reduced_param_grad_range[1]]
+                                    self.grads_for_norm_per_layer[global_layer_id].append(grad)
+
                                 grad_found = True
                                 break
                         if grad_found:
@@ -249,23 +259,21 @@ class MegatronOptimizer(ABC):
         return total_norm
 
     @torch.no_grad()
-    def get_grad_norm_per_layer(self):
+    def get_grad_norm_per_layer(self, num_layers, global_layer_offset, extra_patterns):
         """Compute and return per-layer grad norm."""
-        grads_for_norm_per_layer = self.get_main_grads_for_grad_norm_per_layer()
-
-        args = get_args()
-        extra_patterns = args.log_grad_norm_per_layer_extra_patterns
-        total_norm_per_layer = [0] * (args.num_layers + len(extra_patterns))
+        grads_for_norm_per_layer = self.get_main_grads_for_grad_norm_per_layer(global_layer_offset)
+        total_norm_per_layer = [0] * (num_layers + len(extra_patterns))
         for global_layer_id in grads_for_norm_per_layer:
             grads_for_norm = grads_for_norm_per_layer[global_layer_id]
             # Do not reduce along PP dimension
             total_norm = get_grad_norm_fp32(
-                grads_for_norm, grad_stats_parallel_group=parallel_state.get_tensor_model_parallel_group()
+                grads_for_norm,
+                grad_stats_parallel_group=parallel_state.get_tensor_and_data_parallel_group(with_context_parallel=True)
             )
             if isinstance(global_layer_id, str):
                 for idx, pattern in enumerate(extra_patterns):
                     if pattern in global_layer_id:
-                        total_norm_per_layer[args.num_layers + idx] = total_norm
+                        total_norm_per_layer[num_layers + idx] = total_norm
                         break
             else:
                 total_norm_per_layer[global_layer_id] = total_norm
@@ -275,10 +283,10 @@ class MegatronOptimizer(ABC):
             total_norm_per_layer_cuda, op=torch.distributed.ReduceOp.SUM, group=parallel_state.get_pipeline_model_parallel_group()
         )
         total_norm_dict = {}
-        for idx in range(args.num_layers):
+        for idx in range(num_layers):
             total_norm_dict[f'layer-{idx}'] = total_norm_per_layer_cuda[idx].item()
         for idx, pattern in enumerate(extra_patterns):
-            total_norm_dict[pattern] = total_norm_per_layer_cuda[args.num_layers + idx].item()
+            total_norm_dict[pattern] = total_norm_per_layer_cuda[num_layers + idx].item()
         return total_norm_dict
 
     def clip_grad_norm(self, clip_grad: float) -> float:

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -11,6 +11,9 @@ from logging import getLogger
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
+from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+from megatron.training import get_args
+from megatron.training.arguments import core_transformer_config_from_args
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_scale
@@ -153,6 +156,59 @@ class MegatronOptimizer(ABC):
 
         return grads_for_norm
 
+    def get_main_grads_for_grad_norm_per_layer(self) -> Dict[Union[int, str], List[torch.Tensor]]:
+        """
+        Get per-layer main_grads that should be taken into account to compute the grad norm.
+        Currently only support DistributedDataParallel (DDP).
+        """
+        if not hasattr(self, 'grads_for_norm_per_layer'):
+            self.grads_for_norm_per_layer = {}
+
+            args = get_args()
+            transformer_config = core_transformer_config_from_args(args)
+            global_layer_offset = get_transformer_layer_offset(transformer_config)
+
+            if isinstance(self, ChainedOptimizer):
+                model_chunks = self.model_chunks
+            else:
+                model_chunks = self.optimizer.model_chunks
+
+            for model_chunk in model_chunks:
+                named_parameters = model_chunk.named_parameters()
+
+                for name, param in named_parameters:
+                    # Find global_layer_id for param
+                    if 'layers' in name:
+                        name_segments = name.split('.')
+                        local_layer_id = None
+                        for idx, param_name_segment in enumerate(name_segments):
+                            if param_name_segment == 'layers':
+                                local_layer_id = int(name_segments[idx + 1])
+                                break
+                        global_layer_id = global_layer_offset + local_layer_id
+                    else:
+                        global_layer_id = name
+
+                    if global_layer_id not in self.grads_for_norm_per_layer:
+                        self.grads_for_norm_per_layer[global_layer_id] = []
+
+                    # Find grad for param
+                    grad_found = False
+                    for buffers in [model_chunk.buffers, model_chunk.expert_parallel_buffers]:
+                        for buffer in buffers:
+                            if param in buffer.param_to_bucket:
+                                bucket = buffer.param_to_bucket[param]
+                                grad_data = bucket.grad_data
+                                param_start_index, param_end_index, _ = buffer.param_index_map[param]
+                                grad = grad_data[param_start_index - bucket.offset : param_end_index - bucket.offset]
+                                self.grads_for_norm_per_layer[global_layer_id].append(grad)
+                                grad_found = True
+                                break
+                        if grad_found:
+                            break
+
+        return self.grads_for_norm_per_layer
+
     def get_grad_stats_parallel_group(self) -> torch.distributed.ProcessGroup:
         """Process group for reducing gradient statistics (num_zeros & norm).
 
@@ -191,6 +247,39 @@ class MegatronOptimizer(ABC):
             grads_for_norm, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
         )
         return total_norm
+
+    @torch.no_grad()
+    def get_grad_norm_per_layer(self):
+        """Compute and return per-layer grad norm."""
+        grads_for_norm_per_layer = self.get_main_grads_for_grad_norm_per_layer()
+
+        args = get_args()
+        extra_patterns = args.log_grad_norm_per_layer_extra_patterns
+        total_norm_per_layer = [0] * (args.num_layers + len(extra_patterns))
+        for global_layer_id in grads_for_norm_per_layer:
+            grads_for_norm = grads_for_norm_per_layer[global_layer_id]
+            # Do not reduce along PP dimension
+            total_norm = get_grad_norm_fp32(
+                grads_for_norm, grad_stats_parallel_group=parallel_state.get_tensor_model_parallel_group()
+            )
+            if isinstance(global_layer_id, str):
+                for idx, pattern in enumerate(extra_patterns):
+                    if pattern in global_layer_id:
+                        total_norm_per_layer[args.num_layers + idx] = total_norm
+                        break
+            else:
+                total_norm_per_layer[global_layer_id] = total_norm
+        # Get grad norms of all layers by reducing across PP dimension
+        total_norm_per_layer_cuda = torch.tensor(total_norm_per_layer, dtype=torch.float, device='cuda')
+        torch.distributed.all_reduce(
+            total_norm_per_layer_cuda, op=torch.distributed.ReduceOp.SUM, group=parallel_state.get_pipeline_model_parallel_group()
+        )
+        total_norm_dict = {}
+        for idx in range(args.num_layers):
+            total_norm_dict[f'layer-{idx}'] = total_norm_per_layer_cuda[idx].item()
+        for idx, pattern in enumerate(extra_patterns):
+            total_norm_dict[pattern] = total_norm_per_layer_cuda[args.num_layers + idx].item()
+        return total_norm_dict
 
     def clip_grad_norm(self, clip_grad: float) -> float:
         """Compute and return grad norm, also clip grads."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -967,6 +967,10 @@ def validate_args(args, defaults={}):
             + f"The supported position embedding types are rope and none."
         )
 
+    # Logging.
+    if args.log_grad_norm_per_layer:
+        assert not args.use_torch_fsdp2 and not args.use_custom_fsdp, "Per-layer grad norm logging only supports DistributedDataParallel."
+
     # Print arguments.
     _print_args("arguments", args)
 
@@ -1406,6 +1410,12 @@ def _add_logging_args(parser):
                        help='If set, log progress (in terms of number of processed tokens and '
                        'number of floating-point operations) to progress.txt file in checkpoint '
                        'directory.')
+    group.add_argument('--log-grad-norm-per-layer', action='store_true',
+                       help='If set, calculate and log per-layer gradient norm.')
+    group.add_argument('--log-grad-norm-per-layer-extra-patterns',
+                       nargs='*', type=str, default=[],
+                       help='For per-layer gradient norm logging, naming patterns of extra weights '
+                       'that don\'t belong to any layer.')
     group.add_argument('--timing-log-level', type=int,
                        default=0, choices=range(0,3),
                        help='Granularity level to measure and report timing. '

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -968,8 +968,8 @@ def validate_args(args, defaults={}):
         )
 
     # Logging.
-    if args.log_grad_norm_per_layer:
-        assert not args.use_torch_fsdp2 and not args.use_custom_fsdp, "Per-layer grad norm logging only supports DistributedDataParallel."
+    if args.log_grad_norm_per_layer and not (args.use_distributed_optimizer and not args.use_custom_fsdp):
+        print("Warning: --log-grad-norm-per-layer only supports DistributedDataParallel. Ignoring.")
 
     # Print arguments.
     _print_args("arguments", args)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -969,7 +969,8 @@ def validate_args(args, defaults={}):
 
     # Logging.
     if args.log_grad_norm_per_layer and not (args.use_distributed_optimizer and not args.use_custom_fsdp):
-        print("Warning: --log-grad-norm-per-layer only supports DistributedDataParallel. Ignoring.")
+        print("Warning: --log-grad-norm-per-layer only supports DistributedDataParallel. Disabling.")
+        args.log_grad_norm_per_layer = False
 
     # Print arguments.
     _print_args("arguments", args)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2102,7 +2102,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
         grad_norm_per_layer = None
         if args.log_grad_norm_per_layer and (args.use_distributed_optimizer and not args.use_custom_fsdp):
             grad_norm_per_layer = optimizer.get_grad_norm_per_layer(
-                global_layer_offset, args.num_layers, args.log_grad_norm_per_layer_extra_patterns)
+                args.num_layers, global_layer_offset, args.log_grad_norm_per_layer_extra_patterns)
         report_memory_flag = training_log(loss_dict, total_loss_dict,
                                           learning_rate,
                                           decoupled_learning_rate,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1347,7 +1347,7 @@ def train_step(forward_step_func, data_iterator,
 
 def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_rate, iteration,
                  loss_scale, report_memory_flag, skipped_iter,
-                 grad_norm, params_norm, num_zeros_in_grad):
+                 grad_norm, params_norm, num_zeros_in_grad, grad_norm_per_layer=None):
     """Log training information such as losses, timing, ...."""
     args = get_args()
     timers = get_timers()
@@ -1476,6 +1476,15 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
             if wandb_writer:
                 wandb_writer.log({'grad-norm': grad_norm}, iteration)
                 wandb_writer.log({'grad-norm-with-scale': grad_norm * loss_scale}, iteration)
+        if grad_norm_per_layer is not None:
+            for key in grad_norm_per_layer:
+                grad_norm_value = grad_norm_per_layer[key]
+                writer.add_scalar(f'grad-norm-{key}', grad_norm_value, iteration)
+                writer.add_scalar(f'grad-norm-{key} vs samples', grad_norm_value,
+                                  args.consumed_train_samples)
+                if wandb_writer:
+                    wandb_writer.log({f'grad-norm-{key}': grad_norm_value}, iteration)
+                    wandb_writer.log({f'grad-norm-with-scale-{key}': grad_norm_value * loss_scale}, iteration)
         if num_zeros_in_grad is not None:
             writer.add_scalar('num-zeros', num_zeros_in_grad, iteration)
             writer.add_scalar('num-zeros vs samples', num_zeros_in_grad,
@@ -2083,12 +2092,16 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                 decoupled_learning_rate = param_group['lr']
             else:
                 learning_rate = param_group['lr']
+        grad_norm_per_layer = None
+        if args.log_grad_norm_per_layer:
+            grad_norm_per_layer = optimizer.get_grad_norm_per_layer()
         report_memory_flag = training_log(loss_dict, total_loss_dict,
                                           learning_rate,
                                           decoupled_learning_rate,
                                           iteration, loss_scale,
                                           report_memory_flag, skipped_iter,
-                                          grad_norm, params_norm, num_zeros_in_grad)
+                                          grad_norm, params_norm, num_zeros_in_grad,
+                                          grad_norm_per_layer=grad_norm_per_layer)
 
         # Evaluation.
         if args.eval_interval and iteration % args.eval_interval == 0 and \

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1985,7 +1985,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
         print_rank_0(f">>> Weight hashes match after {iteration} iterations...")
 
     # Prepare global layer offset for per-layer grad norm.
-    if args.log_grad_norm_per_layer and (args.use_distributed_optimizer and not args.use_custom_fsdp):
+    if args.log_grad_norm_per_layer:
         global_layer_offset = get_transformer_layer_offset(core_transformer_config_from_args(args))
 
     # Run training iterations till done.
@@ -2100,7 +2100,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
             else:
                 learning_rate = param_group['lr']
         grad_norm_per_layer = None
-        if args.log_grad_norm_per_layer and (args.use_distributed_optimizer and not args.use_custom_fsdp):
+        if args.log_grad_norm_per_layer:
             grad_norm_per_layer = optimizer.get_grad_norm_per_layer(
                 args.num_layers, global_layer_offset, args.log_grad_norm_per_layer_extra_patterns)
         report_memory_flag = training_log(loss_dict, total_loss_dict,

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -84,6 +84,9 @@ from megatron.core.num_microbatches_calculator import (
     get_num_microbatches,
     update_num_microbatches)
 
+from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+from megatron.training.arguments import core_transformer_config_from_args
+
 from .async_utils import maybe_finalize_async_save
 from .ckpt_utils import CkptUploadQueue
 from .utils import (
@@ -1981,6 +1984,10 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
         torch.distributed.barrier()
         print_rank_0(f">>> Weight hashes match after {iteration} iterations...")
 
+    # Prepare global layer offset for per-layer grad norm.
+    if args.log_grad_norm_per_layer and (args.use_distributed_optimizer and not args.use_custom_fsdp):
+        global_layer_offset = get_transformer_layer_offset(core_transformer_config_from_args(args))
+
     # Run training iterations till done.
     while iteration < args.train_iters:
         if args.profile and torch.distributed.get_rank() in args.profile_ranks:
@@ -2093,8 +2100,9 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
             else:
                 learning_rate = param_group['lr']
         grad_norm_per_layer = None
-        if args.log_grad_norm_per_layer:
-            grad_norm_per_layer = optimizer.get_grad_norm_per_layer()
+        if args.log_grad_norm_per_layer and (args.use_distributed_optimizer and not args.use_custom_fsdp):
+            grad_norm_per_layer = optimizer.get_grad_norm_per_layer(
+                global_layer_offset, args.num_layers, args.log_grad_norm_per_layer_extra_patterns)
         report_memory_flag = training_log(loss_dict, total_loss_dict,
                                           learning_rate,
                                           decoupled_learning_rate,

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -174,6 +174,7 @@ def test_optim_get_grad_norm_per_layer():
     seq = 4
     mbs = 1
     pp = 2
+    num_experts = 2
     ep = 2
 
     _init_distributed(world, rank)
@@ -185,11 +186,15 @@ def test_optim_get_grad_norm_per_layer():
     model_parallel_cuda_manual_seed(seed)
 
     transformer_config = TransformerConfig(
-        num_layers=num_layers // pp, hidden_size=hidden_size, num_attention_heads=4, num_moe_experts=2
+        num_layers=num_layers // pp,
+        hidden_size=hidden_size,
+        num_attention_heads=4,
+        num_moe_experts=num_experts,
+        expert_model_parallel_size=ep,
     )
     model = GPTModel(
         config=transformer_config,
-        transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(),
+        transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(num_experts=num_experts),
         vocab_size=128,
         max_sequence_length=4,
         pre_process=parallel_state.is_pipeline_first_stage(),
@@ -217,6 +222,17 @@ def test_optim_get_grad_norm_per_layer():
     )
     optim = get_megatron_optimizer(optimizer_config, [model])
 
+    global_layer_offset = num_layers // pp * pp_rank
+
+    assert len(optim.chained_optimizers) == 2 # dense and moe
+    assert not hasattr(optim, 'grads_for_norm_per_layer')
+    grads_for_norm_per_layer = optim.get_main_grads_for_grad_norm_per_layer(global_layer_offset)
+    assert hasattr(optim, 'grads_for_norm_per_layer')
+    if pp_rank == 0:
+        assert len(grads_for_norm_per_layer) == 3 # embedding.{weight|bias}, layer-0
+    else:
+        assert len(grads_for_norm_per_layer) == 4 # layer-1, output_layer.weight, final_layernoem.{weight|bias}
+
     for _ in range(2):
         output = model(input_ids, position_ids, attention_mask, labels=labels, loss_mask=loss_mask)
         loss = output.mean()
@@ -224,11 +240,14 @@ def test_optim_get_grad_norm_per_layer():
         _, grad_norm, _ = optim.step()
         grad_norm_per_layer = optim.get_grad_norm_per_layer(
             num_layers,
-            num_layers // pp * pp_rank,
+            global_layer_offset,
             ['embedding', 'output_layer', 'final_layernorm']
         )
+        assert len(grad_norm_per_layer) == 5
+        for name in ['embedding', 'layer-0', 'layer-1', 'output_layer', 'final_layernorm']:
+            assert name in grad_norm_per_layer
         assert torch.isclose(
             torch.tensor(grad_norm**2),
             torch.tensor(sum([x**2 for x in grad_norm_per_layer.values()])),
-            rtol=1e-3
+            rtol=1e-2
         )

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -6,8 +6,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.optim import SGD, Adam
 
+from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 from megatron.core.optimizer import ChainedOptimizer, OptimizerConfig, get_megatron_optimizer
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 from tests.unit_tests.test_utils import _deinit_distributed, _init_distributed
@@ -160,3 +164,71 @@ def test_optim_sharded_state_dict(use_distributed_optimizer: bool, precision: st
             'common_step' not in sharded_state_dict['optimizer']['state']
             or sharded_state_dict['optimizer']['state']['common_step'] is not None
         ), "Found 'optimizer.state.common_step=None' in sharded state dict."
+
+
+def test_optim_get_grad_norm_per_layer():
+    world = int(os.getenv('WORLD_SIZE', '1'))
+    rank = int(os.getenv('RANK', '0'))
+    num_layers = 2
+    hidden_size = 128
+    seq = 4
+    mbs = 1
+    pp = 2
+    ep = 2
+
+    _init_distributed(world, rank)
+    Utils.initialize_model_parallel(pipeline_model_parallel_size=pp, expert_model_parallel_size=ep)
+    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+
+    seed = 42
+    torch.manual_seed(seed)
+    model_parallel_cuda_manual_seed(seed)
+
+    transformer_config = TransformerConfig(
+        num_layers=num_layers // pp, hidden_size=hidden_size, num_attention_heads=4, num_moe_experts=2
+    )
+    model = GPTModel(
+        config=transformer_config,
+        transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(),
+        vocab_size=128,
+        max_sequence_length=4,
+        pre_process=parallel_state.is_pipeline_first_stage(),
+        post_process=parallel_state.is_pipeline_last_stage(),
+    ).cuda()
+
+    data = list(range(seq))
+    input_ids = torch.tensor(data, dtype=torch.int64).repeat((mbs, 1)).cuda()
+    position_ids = torch.tensor(data, dtype=torch.int64).repeat((mbs, 1)).cuda()
+    attention_mask = torch.ones((mbs, 1, seq, seq), dtype=bool).cuda()
+    labels = 1 + torch.tensor(data, dtype=torch.int64).repeat((mbs, 1)).cuda()
+    loss_mask = torch.ones(seq).repeat((mbs, 1)).cuda()
+    if parallel_state.is_pipeline_last_stage():
+        input_tensor = torch.randn((seq, mbs, hidden_size)).cuda()
+        model.set_input_tensor(input_tensor)
+
+    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+    model = DistributedDataParallel(transformer_config, ddp_config, model)
+    optimizer_config = OptimizerConfig(
+        optimizer='adam',
+        bf16=True,
+        use_distributed_optimizer=True,
+        lr=1e-3,
+        clip_grad=0.0
+    )
+    optim = get_megatron_optimizer(optimizer_config, [model])
+
+    for _ in range(2):
+        output = model(input_ids, position_ids, attention_mask, labels=labels, loss_mask=loss_mask)
+        loss = output.mean()
+        loss.backward()
+        _, grad_norm, _ = optim.step()
+        grad_norm_per_layer = optim.get_grad_norm_per_layer(
+            num_layers,
+            num_layers // pp * pp_rank,
+            ['embedding', 'output_layer', 'final_layernorm']
+        )
+        assert torch.isclose(
+            torch.tensor(grad_norm**2),
+            torch.tensor(sum([x**2 for x in grad_norm_per_layer.values()])),
+            rtol=1e-3
+        )


### PR DESCRIPTION
Adds per-layer grad norm logs for model training diagnosis.

Leverages `_ParamAndGradBuffer` from DDP to get gradients for all named parameters. Removes grad norm reducing in PP dimension to get per-layer results.

Currently only supports DistributedDataParallel. Use `--log-grad-norm-per-layer` to enable. For extra weights that don't belong to any layer, use `--log-grad-norm-per-layer-extra-patterns` to specify their naming patterns, e.g., `--log-grad-norm-per-layer-extra-patterns embedding output_layer final_layernorm`.