### PR TITLE
Logging - Add detailed MoE metrics 

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -797,6 +797,13 @@ def track_moe_metrics(
                         {f"moe/{name}_layer_{i}": val for i, val in enumerate(metric_list.tolist())},
                         iteration,
                     )
+
+        wandb_info = dict()
+        for name, metric_list in token_metrics.items():
+            if wandb_writer is not None:
+                wandb_info.update({f'moe-expert/{name}_layer{i}_expert{j}': metric_list[i][j].item() for i in range(len(metric_list)) for j in range(len(metric_list[i]))})
+        if wandb_writer is not None:
+            wandb_writer.log(wandb_info, iteration)
     clear_aux_losses_tracker()
 
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -187,6 +187,15 @@ class TopKRouter(Router):
             _, indices = torch.topk(logits, k=self.topk, dim=1)
         map = torch.zeros_like(logits).int().scatter(1, indices, 1).bool()
         scores = logits * map
+        if self.training:
+            tokens_per_expert = map.sum(dim=0)
+
+            save_to_tokens_per_expert_tracker(
+                "sinkhorn_tokens_per_expert",
+                tokens_per_expert,
+                self.layer_number,
+                self.config.num_layers,
+                reduce_group=parallel_state.get_data_parallel_group())
         return scores, map
 
     def compute_routing_scores_for_aux_loss(self, logits: torch.Tensor) -> torch.Tensor:
@@ -247,6 +256,12 @@ class TopKRouter(Router):
             probs = self.apply_load_balancing_loss(
                 activation=probs, load_balancing_loss_func=aux_loss_func
             )
+            save_to_tokens_per_expert_tracker(
+                "aux_tokens_per_expert",
+                tokens_per_expert,
+                self.layer_number,
+                self.config.num_layers,
+                reduce_group=parallel_state.get_data_parallel_group())
         return probs, routing_map
 
     def seq_aux_loss_load_balancing(self, logits: torch.Tensor, bsz: int, seq_length: int):
@@ -292,6 +307,12 @@ class TopKRouter(Router):
                 activation=probs, load_balancing_loss_func=aux_loss_func
             )
 
+            save_to_tokens_per_expert_tracker(
+                "seq_aux_tokens_per_expert",
+                tokens_per_expert,
+                self.layer_number,
+                self.config.num_layers,
+                reduce_group=parallel_state.get_data_parallel_group())
         return probs, routing_map
 
     def global_batch_loss_load_balancing(self, logits: torch.Tensor):


### PR DESCRIPTION
- Tokens count for all kinds of MoE losses
- Detailed metrics log, such as tokens per expert, not just mean, max and min