### PR TITLE
Logging - Log MoE token metrics for all kinds of aux losses

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -187,6 +187,17 @@ class TopKRouter(Router):
             _, indices = torch.topk(logits, k=self.topk, dim=1)
         map = torch.zeros_like(logits).int().scatter(1, indices, 1).bool()
         scores = logits * map
+
+        if self.training and self.config.moe_tokens_logging:
+            tokens_per_expert = map.sum(dim=0)
+
+            save_to_tokens_per_expert_tracker(
+                "sinkhorn_tokens_per_expert",
+                tokens_per_expert,
+                self.layer_number,
+                self.config.num_layers,
+                reduce_group=parallel_state.get_data_parallel_group())
+            
         return scores, map
 
     def compute_routing_scores_for_aux_loss(self, logits: torch.Tensor) -> torch.Tensor:
@@ -247,6 +258,15 @@ class TopKRouter(Router):
             probs = self.apply_load_balancing_loss(
                 activation=probs, load_balancing_loss_func=aux_loss_func
             )
+
+            if self.config.moe_tokens_logging:
+                save_to_tokens_per_expert_tracker(
+                    "aux_tokens_per_expert",
+                    tokens_per_expert,
+                    self.layer_number,
+                    self.config.num_layers,
+                    reduce_group=parallel_state.get_data_parallel_group())
+            
         return probs, routing_map
 
     def seq_aux_loss_load_balancing(self, logits: torch.Tensor, bsz: int, seq_length: int):
@@ -292,6 +312,14 @@ class TopKRouter(Router):
                 activation=probs, load_balancing_loss_func=aux_loss_func
             )
 
+            if self.config.moe_tokens_logging:
+                save_to_tokens_per_expert_tracker(
+                    "seq_aux_tokens_per_expert",
+                    tokens_per_expert,
+                    self.layer_number,
+                    self.config.num_layers,
+                    reduce_group=parallel_state.get_data_parallel_group())
+            
         return probs, routing_map
 
     def global_batch_loss_load_balancing(self, logits: torch.Tensor):
@@ -331,13 +359,14 @@ class TopKRouter(Router):
             probs = self.apply_load_balancing_loss(
                 activation=probs, load_balancing_loss_func=aux_loss_func
             )
-
-            save_to_tokens_per_expert_tracker(
-                "global_batch_tokens_per_expert",
-                tokens_per_expert,
-                self.layer_number,
-                self.config.num_layers,
-                reduce_group=parallel_state.get_data_parallel_group())
+            
+            if self.config.moe_tokens_logging:
+                save_to_tokens_per_expert_tracker(
+                    "global_batch_tokens_per_expert",
+                    tokens_per_expert,
+                    self.layer_number,
+                    self.config.num_layers,
+                    reduce_group=parallel_state.get_data_parallel_group())
 
         return probs, routing_map
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -446,6 +446,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_per_layer_logging: bool = False
     """Enable per-layer logging for MoE, currently supports auxiliary loss and z loss."""
 
+    moe_tokens_logging: bool = False
+    """Enable logging of the number of tokens per expert in MoE layers."""
+
     moe_expert_capacity_factor: Optional[float] = None
     """moe_expert_capacity_factor (float): The capacity factor for each expert, None means no token
     will be dropped. The default is None."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2590,7 +2590,7 @@ def _add_moe_args(parser):
     group.add_argument('--moe-per-layer-logging', action='store_true',
                        help='Enable per-layer logging for MoE, currently supports auxiliary loss and z loss.')
     group.add_argument('--moe-tokens-logging', action='store_true',
-                        help='Enable logging of the number of tokens. ')
+                       help='Enable logging of the number of tokens per expert in MoE layers.')
     # Token dispatcher arguments
     group.add_argument('--moe-token-dispatcher-type', type=str,
                        choices=['allgather', 'alltoall', 'flex', 'alltoall_seq'],

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2589,6 +2589,8 @@ def _add_moe_args(parser):
                        help='Add noise to the input tensor by applying jitter with a specified epsilon value.')
     group.add_argument('--moe-per-layer-logging', action='store_true',
                        help='Enable per-layer logging for MoE, currently supports auxiliary loss and z loss.')
+    group.add_argument('--moe-tokens-logging', action='store_true',
+                        help='Enable logging of the number of tokens. ')
     # Token dispatcher arguments
     group.add_argument('--moe-token-dispatcher-type', type=str,
                        choices=['allgather', 'alltoall', 'flex', 'alltoall_seq'],

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1515,7 +1515,13 @@ def training_log(loss_dict, total_loss_dict, learning_rate, decoupled_learning_r
         track_names = []
         if args.moe_router_load_balancing_type in ["aux_loss", "seq_aux_loss", "global_batch_loss"]:
             track_names.append("load_balancing_loss")
-            if args.moe_router_load_balancing_type == "global_batch_loss":
+            if args.moe_router_load_balancing_type == "sinkhorn":
+                track_names.append("sinkhorn_tokens_per_expert")
+            elif args.moe_router_load_balancing_type == "aux_loss":
+                track_names.append("aux_tokens_per_expert")
+            elif args.moe_router_load_balancing_type == "seq_aux_loss":
+                track_names.append("seq_aux_tokens_per_expert")
+            elif args.moe_router_load_balancing_type == "global_batch_loss":
                 track_names.append("global_batch_tokens_per_expert")
         if args.moe_z_loss_coeff is not None:
             track_names.append("z_loss")


### PR DESCRIPTION
Add tokens routed metrics for all kinds of MoE aux losses, and make such logging optional.