### PR TITLE
CI/CD - Remove libtcmalloc dependency in test script for AMD platform

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
@@ -1,9 +1,5 @@
 set -e
 
-# Fix "Resource temporarily unavailable Fatal Python error: Aborted" issue on ROCm
-apt-get install -y libtcmalloc-minimal4
-export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4"
-
 pip install -r requirements_ci.txt
 pip install mock
 


### PR DESCRIPTION
Remove `libtcmalloc` dependency in test script for AMD platform, since it's not required.