### PR TITLE
[WIP] Parallelism - Enable arbitrary pipeline split in (interleaved) 1F1B-PP by monkey patching

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2085,6 +2085,13 @@ def _add_distributed_args(parser):
                        type=int, default=None,
                        help=('The number of transformer layers on the last pipeline stage of the decoder. '
                        'Default None is even split of transformer layers across all pipeline stages'))
+    group.add_argument('--decoder-pipeline-manual-split-list', nargs='+', type=int, default=None, help=
+                       ('The pipeline split list of the layers, relaxing the divisibility restriciton '
+                       'of the current interleaved-1f1b schedule. The layer split or number of each pp '
+                       'rank is split_list[pp_rank*vp_size:(pp_rank+1)*vp_size] or split_list[pp_rank] '
+                       'when interleaved pipeline is used or not. For example, the split list could be '
+                       '"7 8 9 8" in layer32-pp4 config, or "3 4 4 4 5 4 4 4" in layer32-pp4-vpp2 config, '
+                       'where the vpp split of pp_rank0/pp_rank1/pp_rank2/pp_rank3 is [3,4]/[4,4]/[5,4]/[4,4]'))
     group.add_argument('--model-parallel-size', type=int, default=None,
                        help='Old model parallel argument, do not use. Use '
                        '--tensor-model-parallel-size instead.')

--- a/megatron/training/patch.py
+++ b/megatron/training/patch.py
@@ -1,0 +1,138 @@
+import megatron
+from megatron.core import parallel_state
+from megatron.core.transformer import TransformerConfig
+
+
+def set_manual_pipeline_split_patch(args):
+    """
+    Monkey-patch note:
+    - The original function will be replaced at runtime by this implementation.
+
+    """
+
+    # patch TransformerConfig.__post_init__ to add validation
+    TransformerConfig.decoder_pipeline_manual_split_list = (
+        args.decoder_pipeline_manual_split_list
+    )
+    TransformerConfig.num_layers_per_virtual_pipeline_stage = (
+        args.num_layers_per_virtual_pipeline_stage
+    )
+
+    def validate_manual_split(func):
+        def wrapper(self, *args, **kwargs):
+
+            if (
+                self.num_layers_per_virtual_pipeline_stage is not None
+                or self.num_layers_in_first_pipeline_stage is not None
+                or self.num_layers_in_last_pipeline_stage is not None
+                or self.account_for_embedding_in_pipeline_split
+                or self.account_for_loss_in_pipeline_split
+            ):
+                raise ValueError(
+                    "decoder_pipeline_manual_split_list is not compatible "
+                    "with num_layers_per_virtual_pipeline_stage/"
+                    "decoder_first_pipeline_num_layers/"
+                    "decoder_last_pipeline_num_layers/"
+                    "account_for_embedding_in_pipeline_split/"
+                    "account_for_loss_in_pipeline_split yet"
+                )
+
+            num_layers = self.num_layers
+            pp_size = self.pipeline_model_parallel_size
+            vp_size = self.virtual_pipeline_model_parallel_size
+            pp_split = self.decoder_pipeline_manual_split_list
+
+            if pp_size <= 1:
+                raise ValueError(
+                    f"pipeline_model_parallel_size={pp_size} should be larger "
+                    f"than 1 when decoder_pipeline_manual_split_list is used"
+                )
+
+            if not isinstance(pp_split, list):
+                raise ValueError(
+                    f"type of decoder_pipeline_manual_split_list={pp_split} "
+                    f"is {type(pp_split)} and should be a list")
+
+            split_size = pp_size if vp_size is None else pp_size * vp_size
+            if len(pp_split) != split_size:
+                raise ValueError(
+                    f"the size of decoder_pipeline_manual_split_list="
+                    f"{pp_split} should be {split_size} "
+                    f"given pipeline_model_parallel_size={pp_size} and "
+                    f"virtual_pipeline_model_parallel_size={vp_size}"
+                )
+
+            if not all(x > 0 for x in pp_split):
+                raise ValueError(
+                    f"layer numbers in decoder_pipeline_manual_split_list"
+                    f"={pp_split} should all be larger than 0"
+                )
+
+            if sum(pp_split) != num_layers:
+                raise ValueError(
+                    f"the sum of decoder_pipeline_manual_split_list="
+                    f"{pp_split} is {sum(pp_split)} and "
+                    f"should be equal to num_layers={num_layers}"
+                )
+            
+            func(self, *args, **kwargs)
+        return wrapper
+
+    TransformerConfig.__post_init__ = validate_manual_split(
+        TransformerConfig.__post_init__
+    )
+
+    # patch get_num_layers_to_build
+    def get_num_layers_to_build_patch(config):
+        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+        vp_size = config.virtual_pipeline_model_parallel_size
+        vp_rank = parallel_state.get_virtual_pipeline_model_parallel_rank()
+        pp_idx = pp_rank if vp_size is None else pp_rank * vp_size + vp_rank
+        num_layers_to_build = config.decoder_pipeline_manual_split_list[pp_idx]
+        return num_layers_to_build
+
+    megatron.core.transformer.transformer_block.get_num_layers_to_build = (
+        get_num_layers_to_build_patch
+    )
+    megatron.core.models.gpt.gpt_layer_specs.get_num_layers_to_build = (
+        get_num_layers_to_build_patch
+    )
+
+    # patch get_transformer_layer_offset
+    def get_transformer_layer_offset_patch(config):
+        pp_size = config.pipeline_model_parallel_size
+        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+        vp_size = config.virtual_pipeline_model_parallel_size
+        vp_rank = parallel_state.get_virtual_pipeline_model_parallel_rank()
+
+        if not parallel_state.is_inside_encoder():
+            pp_decoder_start = (
+                parallel_state.get_pipeline_model_parallel_decoder_start()
+            )
+            if pp_decoder_start is not None:
+                pp_rank = pp_rank - pp_decoder_start
+
+        offset = 0
+        if vp_rank is not None:
+            for _ in range(vp_rank):
+                for pp_idx in range(pp_size):
+                    offset += config.decoder_pipeline_manual_split_list[
+                        pp_idx * vp_size
+                    ]
+            for pp_idx in range(pp_rank):
+                offset += config.decoder_pipeline_manual_split_list[
+                    pp_idx * vp_size + vp_rank
+                ]
+        else:
+            offset = sum(config.decoder_pipeline_manual_split_list[:pp_rank])
+        return offset
+
+    megatron.core.transformer.transformer_layer.get_transformer_layer_offset = (
+        get_transformer_layer_offset_patch
+    )
+    megatron.core.transformer.transformer_block.get_transformer_layer_offset = (
+        get_transformer_layer_offset_patch
+    )
+    megatron.core.models.gpt.gpt_layer_specs.get_transformer_layer_offset = (
+        get_transformer_layer_offset_patch
+    )

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -680,6 +680,12 @@ def pretrain(
     if args.log_progress:
         append_to_progress_log("Starting job")
 
+    # Enable manually split layers in (interleaved) 1f1b pipeline parallelism by monkey patching
+    if args.decoder_pipeline_manual_split_list is not None:
+        from megatron.training.patch import set_manual_pipeline_split_patch
+        print_rank_0('monkey patch to enable manual pipeline split...')
+        set_manual_pipeline_split_patch(args)
+
     # Initialize fault tolerance
     # NOTE: ft_integration functions other than `setup` are no-op if the FT is not initialized
     if args.enable_ft_package:


### PR DESCRIPTION
- Relax the divisibility restriction of the current (interleaved) 1f1b pipeline schedule by adding `--decoder-pipeline-manual-split-list`
- The layer split or number of each pp rank is `decoder_pipeline_manual_split_list[pp_rank*vp_size:(pp_rank+1)*vp_size]` or `decoder_pipeline_manual_split_list[pp_rank] `when interleaved pipeline is used or not
- e.g.
  - The split list could be "7 8 9 8" in layer32-pp4 config, where the layer number of pp_rank0/pp_rank1/pp_rank2/pp_rank3 is 7/8/9/8
  - The split list could be "3 4 4 4 5 4 4 4" in layer32-pp4-vpp2 config, where the vpp split of pp_rank0/pp_rank1/pp_rank2/pp_rank3 is [3,4]/[4,4]/[5,4]/[4,4]
- [TODO] Add unit tests