### PR TITLE
Tests - Fix failures in tests/unit_tests/test_parallel_state.py

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
@@ -38,7 +38,6 @@ clear_previous_runs() {
 # - dist_checkpointing
 # - models
 # - test_checkpointing
-# - test_parallel_state
 # - transformer
 # All test cases fail in:
 # - inference/engines/test_dynamic_engine.py
@@ -58,7 +57,6 @@ torchrun \
   --ignore tests/unit_tests/models \
   --ignore tests/unit_tests/ssm/test_mamba_hybrid_layer_allocation.py \
   --ignore tests/unit_tests/test_checkpointing.py \
-  --ignore tests/unit_tests/test_parallel_state.py \
   --ignore tests/unit_tests/transformer \
   tests/unit_tests
 
@@ -123,16 +121,6 @@ torchrun \
   --deselect "tests/unit_tests/test_checkpointing.py::test_save_checkpoint[torch]" \
   --deselect "tests/unit_tests/test_checkpointing.py::test_save_checkpoint[torch_dcp]" \
   tests/unit_tests/test_checkpointing.py
-
-clear_previous_runs
-torchrun \
-  ${TORCHRUN_ARGS[@]} \
-  -m pytest -vxs \
-  ${PYTEST_COV_ARGS[@]} \
-  --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp3-2]" \
-  --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp4-2]" \
-  --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp5-2]" \
-  tests/unit_tests/test_parallel_state.py
 
 clear_previous_runs
 torchrun \

--- a/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
@@ -39,7 +39,6 @@ clear_previous_runs() {
 # - dist_checkpointing
 # - models
 # - test_checkpointing
-# - test_parallel_state
 # - test_tokenizer.py \
 # - transformer
 # All test cases fail in:
@@ -55,7 +54,6 @@ torchrun \
   --ignore tests/unit_tests/inference/engines/test_dynamic_engine.py \
   --ignore tests/unit_tests/models \
   --ignore tests/unit_tests/test_checkpointing.py \
-  --ignore tests/unit_tests/test_parallel_state.py \
   --ignore tests/unit_tests/test_tokenizer.py \
   --ignore tests/unit_tests/transformer \
   tests/unit_tests
@@ -100,16 +98,6 @@ torchrun \
   --deselect "tests/unit_tests/test_checkpointing.py::test_save_checkpoint[torch]" \
   --deselect "tests/unit_tests/test_checkpointing.py::test_save_checkpoint[torch_dcp]" \
   tests/unit_tests/test_checkpointing.py
-
-clear_previous_runs
-torchrun \
-  ${TORCHRUN_ARGS[@]} \
-  -m pytest -vxs \
-  ${PYTEST_COV_ARGS[@]} \
-  --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp3-2]" \
-  --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp4-2]" \
-  --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp5-2]" \
-  tests/unit_tests/test_parallel_state.py
 
 clear_previous_runs
 disable_pattern="not test_gpt2_tiktok_tokenizer"

--- a/tests/unit_tests/test_parallel_state.py
+++ b/tests/unit_tests/test_parallel_state.py
@@ -282,6 +282,7 @@ def test_different_initialize_order_unconsistency(src_tp_pp, ep_size):
         )
     except AssertionError as e:
         assert ep_size == 2
+        # Limitation in megatron/core/parallel_state.py::initialize_model_parallel
         assert str(e) == "When not using pp-last rank ordering, the data parallel size of the attention and moe layers must be the same"
         return
 

--- a/tests/unit_tests/test_parallel_state.py
+++ b/tests/unit_tests/test_parallel_state.py
@@ -276,9 +276,15 @@ def test_different_initialize_order_unconsistency(src_tp_pp, ep_size):
 
     Utils.destroy_model_parallel()
 
-    Utils.initialize_model_parallel(
-        *src_tp_pp, expert_model_parallel_size=ep_size, order='tp-pp-ep-dp'
-    )
+    try:
+        Utils.initialize_model_parallel(
+            *src_tp_pp, expert_model_parallel_size=ep_size, order='tp-pp-ep-dp'
+        )
+    except AssertionError as e:
+        assert ep_size == 2
+        assert str(e) == "When not using pp-last rank ordering, the data parallel size of the attention and moe layers must be the same"
+        return
+
     assert tp_g == torch.distributed.get_process_group_ranks(ps.get_tensor_model_parallel_group())
     assert dp_g != torch.distributed.get_process_group_ranks(ps.get_data_parallel_group(False))
     assert pp_g != torch.distributed.get_process_group_ranks(ps.get_pipeline_model_parallel_group())


### PR DESCRIPTION
Fix failures in `tests/unit_tests/test_parallel_state.py` caused by new assertion about EP and DP in `initialize_model_parallel` function from `megatron/core/parallel_state.py`.