### PR TITLE
Tests - Fix failures in tests/unit_tests/transformer/test_attention.py

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
@@ -140,8 +140,5 @@ torchrun \
   -m pytest -vxs \
   ${PYTEST_COV_ARGS[@]} \
   --deselect "tests/unit_tests/transformer/test_retro_attention.py::TestRetroAttention::test_gpu_forward" \
-  --deselect "tests/unit_tests/transformer/test_attention.py::TestParallelAttention::test_gpu_forward" \
-  --deselect "tests/unit_tests/transformer/test_attention.py::TestParallelAttention::test_fused_rope_gpu_forward" \
-  --deselect "tests/unit_tests/transformer/test_attention.py::TestParallelAttention::test_checkpointed_gpu_forward" \
   --ignore "tests/unit_tests/transformer/moe/test_moe_layer_discrepancy.py" \
   tests/unit_tests/transformer

--- a/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
@@ -126,7 +126,4 @@ torchrun \
   -m pytest -vxs \
   ${PYTEST_COV_ARGS[@]} \
   --deselect "tests/unit_tests/transformer/test_retro_attention.py::TestRetroAttention::test_gpu_forward" \
-  --deselect "tests/unit_tests/transformer/test_attention.py::TestParallelAttention::test_gpu_forward" \
-  --deselect "tests/unit_tests/transformer/test_attention.py::TestParallelAttention::test_fused_rope_gpu_forward" \
-  --deselect "tests/unit_tests/transformer/test_attention.py::TestParallelAttention::test_checkpointed_gpu_forward" \
   tests/unit_tests/transformer

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -54,7 +54,7 @@ class TestParallelAttention:
         )
         hidden_states = hidden_states.cuda()
 
-        attention_mask = torch.ones((1, 1, sequence_length, sequence_length), dtype=bool).cuda()
+        attention_mask = torch.ones((micro_batch_size, 1, 1, sequence_length), dtype=bool).cuda()
 
         output, bias = self.parallel_attention(hidden_states, attention_mask)
 
@@ -79,7 +79,7 @@ class TestParallelAttention:
         )
         hidden_states = hidden_states.cuda()
 
-        attention_mask = torch.ones((1, 1, sequence_length, sequence_length), dtype=bool).cuda()
+        attention_mask = torch.ones((micro_batch_size, 1, 1, sequence_length), dtype=bool).cuda()
         rotary_pos_emb = torch.ones(
             sequence_length, 1, 1, self.parallel_attention.config.kv_channels
         ).cuda()
@@ -116,7 +116,7 @@ class TestParallelAttention:
         )
         hidden_states = hidden_states.cuda()
 
-        attention_mask = torch.ones((1, 1, sequence_length, sequence_length), dtype=bool).cuda()
+        attention_mask = torch.ones((micro_batch_size, 1, 1, sequence_length), dtype=bool).cuda()
 
         output, bias = checkpointed_parallel_attention(hidden_states, attention_mask)
 


### PR DESCRIPTION
Fix failures in `tests/unit_tests/transformer/test_attention.py` caused by new attention mask shape `(mbs, 1, 1, seq)` required by latest interface of TransformerEngine, from both [NVIDIA]( https://github.com/NVIDIA/TransformerEngine/blob/v2.4/transformer_engine/pytorch/attention/dot_product_attention/utils.py#L617-L634) and [AMD](https://github.com/ROCm/TransformerEngine/blob/release_v1.14_rocm/transformer_engine/pytorch/attention.py#L641-L658).