### PR TITLE
Tests - Recover test_errors_are_reported test case in dist_checkpointing for AMD

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
@@ -73,7 +73,6 @@ torchrun \
 
 clear_previous_runs
 disable_pattern="not test_dp_sharding and "
-disable_pattern+="not test_errors_are_reported and "
 disable_pattern+="not test_memory_usage and "
 disable_pattern+="not test_remove_sharded_tensors and "
 disable_pattern+="not test_te_grouped_linear_torch_native"


### PR DESCRIPTION
Recover `test_errors_are_reported` test case in `dist_checkpointing` for AMD since it can pass.