### PR TITLE
Tests - Fix unit tests caused by torch.load API change

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_amd_mi300x_1n8g.sh
@@ -3,6 +3,7 @@ set -e
 pip install -r requirements_ci.txt
 pip install mock
 
+export TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 export HIP_FORCE_DEV_KERNARG=1
 export HSA_ENABLE_SDMA=1
@@ -75,8 +76,7 @@ clear_previous_runs
 disable_pattern="not test_dp_sharding and "
 disable_pattern+="not test_errors_are_reported and "
 disable_pattern+="not test_memory_usage and "
-disable_pattern+="not test_remove_sharded_tensors and "
-disable_pattern+="not test_te_grouped_linear_torch_native"
+disable_pattern+="not test_remove_sharded_tensors"
 torchrun \
   ${TORCHRUN_ARGS[@]} \
   -m pytest -vxs \
@@ -97,11 +97,6 @@ torchrun \
   -m pytest -vxs \
   ${PYTEST_COV_ARGS[@]} \
   --deselect "tests/unit_tests/models/test_bert_model.py::TestBertModelAttentionDimensions::test_transformer_engine_version_1_7_to_1_10_rng_error" \
-  --deselect "tests/unit_tests/models/test_clip_vit_model.py::TestCLIPViTModel::test_save_load" \
-  --deselect "tests/unit_tests/models/test_llava_model.py::TestLLaVAModel::test_save_load" \
-  --deselect "tests/unit_tests/models/test_mamba_model.py::TestMambaModel::test_save_load" \
-  --deselect "tests/unit_tests/models/test_multimodal_projector.py::TestMultimodalProjector::test_save_load" \
-  --deselect "tests/unit_tests/models/test_radio_model.py::TestRADIOViTModel::test_save_load" \
   --deselect "tests/unit_tests/models/test_t5_model.py::TestT5Model::test_forward_output_encoder_hidden_only" \
   --deselect "tests/unit_tests/models/test_t5_model.py::TestT5Model::test_forward_with_encoder_hidden_states" \
   --deselect "tests/unit_tests/models/test_t5_model.py::TestT5Model::test_post_process_forward" \

--- a/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
@@ -7,6 +7,7 @@ MAMBA_FORCE_BUILD=TRUE pip install git+https://github.com/state-spaces/mamba.git
 apt purge -y python3-blinker
 pip install flask flask-restful tiktoken tensorstore
 
+export TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 export NCCL_DEBUG=WARN
 export NCCL_SOCKET_IFNAME=eth0


### PR DESCRIPTION
torch.load uses weights_only=True since version 2.6 which is a breaking change and will cause unit tests failed.
Set TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 env to keep the behavior consistent.
Reference: https://docs.pytorch.org/docs/2.6/notes/serialization.html#weights-only