### PR TITLE
Tests - Recover GPT tokenizer tests for NVIDIA platform

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
@@ -40,7 +40,6 @@ clear_previous_runs() {
 # - dist_checkpointing
 # - models
 # - test_parallel_state
-# - test_tokenizer.py \
 # - transformer
 # All test cases fail in:
 # - inference/engines/test_dynamic_engine.py
@@ -55,7 +54,6 @@ torchrun \
   --ignore tests/unit_tests/inference/engines/test_dynamic_engine.py \
   --ignore tests/unit_tests/models \
   --ignore tests/unit_tests/test_parallel_state.py \
-  --ignore tests/unit_tests/test_tokenizer.py \
   --ignore tests/unit_tests/transformer \
   tests/unit_tests
 
@@ -99,15 +97,6 @@ torchrun \
   --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp4-2]" \
   --deselect "tests/unit_tests/test_parallel_state.py::test_different_initialize_order_unconsistency[src_tp_pp5-2]" \
   tests/unit_tests/test_parallel_state.py
-
-clear_previous_runs
-disable_pattern="not test_gpt2_tiktok_tokenizer"
-torchrun \
-  ${TORCHRUN_ARGS[@]} \
-  -m pytest -vxs \
-  ${PYTEST_COV_ARGS[@]} \
-  -k "${disable_pattern}" \
-  tests/unit_tests/test_tokenizer.py
 
 clear_previous_runs
 torchrun \


### PR DESCRIPTION
Recover GPT tokenizer tests for NVIDIA platform since it can pass.