### PR TITLE
Algorithm - Fix all-reduce for global-batch load balancing loss

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -147,7 +147,7 @@ def global_batch_load_balancing_loss_func(
     routing_prob = probs.mean(0)
 
     routing_count = routing_map.int().sum(0)
-    torch.distributed.nn.all_reduce(routing_count, op=torch.distributed.ReduceOp.SUM, group=parallel_state.get_data_parallel_group())
+    torch.distributed.all_reduce(routing_count, op=torch.distributed.ReduceOp.SUM, group=parallel_state.get_data_parallel_group())
 
     # If the sequence is partitioned by certain parallelism strategies like Sequence Parallelism
     # or Context Parallelism, compute the gradient of the auxiliary loss with respect to the full
@@ -155,7 +155,7 @@ def global_batch_load_balancing_loss_func(
     if sequence_partition_group is not None:
         routing_prob /= sequence_partition_group.size()
         routing_prob_count = torch.stack([routing_prob, routing_count])
-        torch.distributed.nn.all_reduce(routing_prob_count, op=torch.distributed.ReduceOp.SUM, group=sequence_partition_group)
+        torch.distributed.all_reduce(routing_prob_count, op=torch.distributed.ReduceOp.SUM, group=sequence_partition_group)
         routing_prob, routing_count = routing_prob_count[0], routing_prob_count[1]
 
     routing_freq = routing_count / routing_count.sum()

--- a/tests/unit_tests/transformer/moe/test_aux_loss.py
+++ b/tests/unit_tests/transformer/moe/test_aux_loss.py
@@ -151,3 +151,48 @@ class TestSeqAuxLoss:
             moe_aux_loss_coeff=0.1,
         )
         container.aux_loss_test(self.input, self.baseline_grad)
+
+class TestGlobalAuxLoss:
+    def setup_method(self, method):
+        baseline_container = AuxlossTestContainer(
+            tp_size=1,
+            ep_size=1,
+            pp_size=1,
+            cp_size=1,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="global_batch_loss",
+            moe_token_dispatcher_type="alltoall",
+            moe_aux_loss_coeff=0.1,
+        )
+        moe_layer = baseline_container.moe_layer
+        self.input = torch.randn((32, 8, moe_layer.config.hidden_size)).cuda()
+        self.input.requires_grad = True
+        probs, indices = moe_layer.router(self.input)
+        probs.sum().mul_(0).backward()  # zero out the main gradients
+        self.baseline_grad = self.input.grad
+        self.input.grad = None
+        clear_aux_losses_tracker()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.internal
+    @pytest.mark.parametrize(
+        "tp_size,ep_size,cp_size", [(8, 1, 1), (4, 2, 1), (1, 1, 8), (2, 1, 4), (2, 2, 2)]
+    )
+    def test_a2a_dispatcher(self, tp_size, ep_size, cp_size):
+        container = AuxlossTestContainer(
+            tp_size=tp_size,
+            ep_size=ep_size,
+            pp_size=1,
+            cp_size=cp_size,
+            num_moe_experts=8,
+            moe_router_topk=2,
+            moe_router_load_balancing_type="global_batch_loss",
+            moe_token_dispatcher_type="alltoall",
+            moe_aux_loss_coeff=0.1,
+        )
+        container.aux_loss_test(self.input, self.baseline_grad)


### PR DESCRIPTION
There are two issues of using torch.distributed.nn.all_reduce for global batch load balancing in existing code:
- torch.distributed.nn.all_reduce is not an in-place function, so routing_count was never all-reduced.
- torch.distributed.nn.all_reduce doesn't produce correct gradients in all-sum scenario, as mentioned in https://github.com/pytorch/pytorch/issues/58005.

This PR fixes the two issues above by replacing torch.distributed.nn.all_reduce with torch.distributed.all_reduce. The grad_fn of torch.distributed.all_reduce node is IdentityOp, which produces correct gradients when reduce op is sum, which is the use case of all-reduce in global batch load balance loss.