### PR TITLE
Algorithm - Remove all-reduce for routing probabilities in global-batch load balancing loss

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -154,9 +154,7 @@ def global_batch_load_balancing_loss_func(
     # sequence.
     if sequence_partition_group is not None:
         routing_prob /= sequence_partition_group.size()
-        routing_prob_count = torch.stack([routing_prob, routing_count])
-        torch.distributed.all_reduce(routing_prob_count, op=torch.distributed.ReduceOp.SUM, group=sequence_partition_group)
-        routing_prob, routing_count = routing_prob_count[0], routing_prob_count[1]
+        torch.distributed.all_reduce(routing_count, op=torch.distributed.ReduceOp.SUM, group=sequence_partition_group)
 
     routing_freq = routing_count / routing_count.sum()
 


### PR DESCRIPTION
Remove all-reduce for `routing_prob` in global-batch load balancing loss.

The theory is that, when calculating gradient for `all_reduced(routing_prob) * all_reduced(routing_count)`:
- We don't need the gradient for `routing_count` part because it's not in model weights and not differentiable
- The gradient of `torch.distributed.all_reduce` node is IdentityOp

As a result, removing all-reduce for `routing_prob` will not affect the gradient of `routing_prob` part, and save latency.