### PR TITLE
Tests - Add basic utilities for module-level numerical tests

### DIFF
--- a/tests/numerical_tests/modules/conftest.py
+++ b/tests/numerical_tests/modules/conftest.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--result-dir', type=str, required=True,
+        help='Directory to store test result',
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup():
+    yield
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+        torch.distributed.destroy_process_group()

--- a/tests/numerical_tests/modules/test_module.py
+++ b/tests/numerical_tests/modules/test_module.py
@@ -1,0 +1,63 @@
+import os
+import torch
+
+from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.module import Float16Module
+from tests.numerical_tests.modules.test_utilities import Utils
+
+
+class TestModule:
+    """
+    Test general modules
+    """
+
+    def setup_method(self, method):
+        self.setup_distributed()
+        self.setup_parallelism()
+        self.setup_random_seed()
+
+    def setup_distributed(self):
+        Utils.initialize_distributed()
+
+    def setup_parallelism(self):
+        Utils.initialize_model_parallel()
+
+    def setup_random_seed(self):
+        seed = 42
+        torch.manual_seed(seed)
+        model_parallel_cuda_manual_seed(seed)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def setup_model_and_optimizer(self, config, model):
+        model = model.cuda()
+        if config.bf16:
+            model = Float16Module(config, model)
+        ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+        model = DistributedDataParallel(config, ddp_config, model)
+        optimizer_config = OptimizerConfig(
+            optimizer='adam',
+            bf16=config.bf16,
+            use_distributed_optimizer=True,
+            lr=1e-3,
+            clip_grad=0.0
+        )
+        optimizer = get_megatron_optimizer(optimizer_config, [model])
+        return model, optimizer
+
+    def save_output(self, inputs, outputs, params, grads, step, request):
+        output_dict = {
+            'inputs': inputs,
+            'outputs': outputs,
+            'params': params,
+            'grads': grads,
+        }
+        result_dir = request.config.getoption('--result-dir')
+        file_tag = request.node.nodeid[request.node.nodeid.find(self.__class__.__name__):]
+        file_tag = file_tag.replace('::', '-').replace('[', '-').replace(']', '')
+        rank = torch.distributed.get_rank()
+        file_name = f'{file_tag}-rank-{rank}-step-{step}.pt'
+        torch.save(output_dict, os.path.join(result_dir, file_name))

--- a/tests/numerical_tests/modules/test_utilities.py
+++ b/tests/numerical_tests/modules/test_utilities.py
@@ -1,0 +1,55 @@
+import os
+
+from tests.unit_tests.test_utilities import Utils as UtilsWithNvtePop
+
+
+class Utils(UtilsWithNvtePop):
+
+    _nvte_keys = ['NVTE_FLASH_ATTN', 'NVTE_FUSED_ATTN', 'NVTE_UNFUSED_ATTN']
+    _nvte_backup = {}
+
+    @staticmethod
+    def _save_nvte_envs():
+        Utils._nvte_backup = {k: os.environ.get(k) for k in Utils._nvte_keys}
+
+    @staticmethod
+    def _restore_nvte_envs():
+        for k, v in Utils._nvte_backup.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    @staticmethod
+    def initialize_distributed():
+        Utils._save_nvte_envs()
+        try:
+            UtilsWithNvtePop.initialize_distributed()
+        finally:
+            Utils._restore_nvte_envs()
+
+    @staticmethod
+    def destroy_model_parallel():
+        Utils._save_nvte_envs()
+        try:
+            UtilsWithNvtePop.destroy_model_parallel()
+        finally:
+            Utils._restore_nvte_envs()
+
+    @staticmethod
+    def initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        virtual_pipeline_model_parallel_size=None,
+        **kwargs,
+    ):
+        Utils._save_nvte_envs()
+        try:
+            UtilsWithNvtePop.initialize_model_parallel(
+                tensor_model_parallel_size,
+                pipeline_model_parallel_size,
+                virtual_pipeline_model_parallel_size,
+                **kwargs,
+            )
+        finally:
+            Utils._restore_nvte_envs()

--- a/tests/numerical_tests/utils/module_mean_and_std.py
+++ b/tests/numerical_tests/utils/module_mean_and_std.py
@@ -1,0 +1,74 @@
+import argparse
+import torch
+import gc
+
+class OnlineTensorStats:
+    """
+    Welford algorithm to calculate mean and std in stream.
+    """
+    def __init__(self):
+        self.n = 0
+        self.mean = None
+        self.M2 = None
+
+    def update(self, x):
+        x = x.detach().float().cpu()
+        if self.mean is None:
+            self.mean = torch.zeros_like(x)
+            self.M2 = torch.zeros_like(x)
+
+        self.n += 1
+        delta = x - self.mean
+        self.mean += delta / self.n
+        delta2 = x - self.mean
+        self.M2 += delta * delta2
+
+    def get_mean_std(self):
+        if self.n < 2:
+            std = torch.zeros_like(self.mean)
+        else:
+            std = torch.sqrt(self.M2 / (self.n - 1))
+        return self.mean, std
+
+def process_file(path, stats_dict):
+    data = torch.load(path, map_location='cpu')
+    for key in data:
+        if key not in stats_dict:
+            stats_dict[key] = []
+        for idx, tensor in enumerate(data[key]):
+            if idx == len(stats_dict[key]):
+                stats_dict[key].append(OnlineTensorStats())
+            stats_dict[key][idx].update(tensor)
+    del data
+    gc.collect()
+
+def main(args):
+    stats_dict = dict()
+
+    with open(args.input_list, 'r') as f:
+        file_paths = [line.strip() for line in f if line.strip()]
+
+    for path in file_paths:
+        process_file(path, stats_dict)
+
+    mean_result = {}
+    std_result = {}
+
+    for key, stats in stats_dict.items():
+        mean_result[key] = []
+        std_result[key] = []
+        for s in stats:
+            mean, std = s.get_mean_std()
+            mean_result[key].append(mean)
+            std_result[key].append(std)
+
+    torch.save(mean_result, args.output_mean_file)
+    torch.save(std_result, args.output_std_file)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Streamed tensor mean/std computation from .pt files.")
+    parser.add_argument('--input-list', type=str, required=True, help='Text file containing list of .pt file paths')
+    parser.add_argument('--output-mean-file', type=str, required=True, help='Output .pt file to save mean values')
+    parser.add_argument('--output-std-file', type=str, required=True, help='Output .pt file to save std values')
+    args = parser.parse_args()
+    main(args)

--- a/tests/numerical_tests/utils/module_similarity.py
+++ b/tests/numerical_tests/utils/module_similarity.py
@@ -1,0 +1,45 @@
+import argparse
+import torch
+import json
+
+def load_stats(path):
+    return torch.load(path, map_location='cpu')
+
+def compare_stats(stats_a, stats_b):
+    result = {}
+
+    for key in stats_a:
+        list_a = stats_a[key]
+        list_b = stats_b[key]
+
+        cosine_similarity = [
+            torch.nn.functional.cosine_similarity(
+                a.view(-1).double(),
+                b.view(-1).double(),
+                dim=0
+            ).item()
+            for a, b in zip(list_a, list_b)
+        ]
+
+        result[key] = {
+            'cosine_similarity': cosine_similarity,
+        }
+
+    return result
+
+def main(args):
+    stats_a = load_stats(args.stats_a)
+    stats_b = load_stats(args.stats_b)
+
+    comparison_result = compare_stats(stats_a, stats_b)
+
+    with open(args.output_file, 'w') as f:
+        json.dump(comparison_result, f, indent=2)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Compare two tensor stats .pt files and compute max relative errors.")
+    parser.add_argument('--stats-a', type=str, required=True, help='Path to stats .pt file from setting A')
+    parser.add_argument('--stats-b', type=str, required=True, help='Path to stats .pt file from setting B')
+    parser.add_argument('--output-file', type=str, required=True, help='Path to save the cosine similarity result (JSON)')
+    args = parser.parse_args()
+    main(args)

--- a/tests/numerical_tests/utils/module_similarity.py
+++ b/tests/numerical_tests/utils/module_similarity.py
@@ -37,7 +37,7 @@ def main(args):
         json.dump(comparison_result, f, indent=2)
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Compare two tensor stats .pt files and compute max relative errors.")
+    parser = argparse.ArgumentParser(description="Compare two tensor stats .pt files and compute cosine similarity.")
     parser.add_argument('--stats-a', type=str, required=True, help='Path to stats .pt file from setting A')
     parser.add_argument('--stats-b', type=str, required=True, help='Path to stats .pt file from setting B')
     parser.add_argument('--output-file', type=str, required=True, help='Path to save the cosine similarity result (JSON)')


### PR DESCRIPTION
Adds basic utilities for module-level numerical tests, in tests/numerical_tests folder. Including:
- modules/conftest.py: common arguments and fixtures for test classes.
- modules/test_module.py: base class to run module-level numerical tests and dump results.
- modules/test_utilities.py: revised Utils class from unit tests, to respect NVTE environmental variables from users.
- utils/module_mean_and_std.py: calculate mean and std of several module test trials.
- utils/module_similarity: calculate cosine similarity of two module test stats. The stats can be either raw value, mean or std.