### PR TITLE
Tests - Add test cases for transformer block in GPT-like models

### DIFF
--- a/tests/numerical_tests/modules/test_attention.py
+++ b/tests/numerical_tests/modules/test_attention.py
@@ -1,0 +1,103 @@
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import (
+    TEDotProductAttention,
+    TELayerNormColumnParallelLinear,
+    TENorm,
+    TERowParallelLinear,
+)
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from tests.numerical_tests.modules.test_module import TestModule
+
+
+class TestSelfAttention(TestModule):
+    """
+    Test SelfAttention
+    """
+
+    @pytest.mark.parametrize('inputs_kv', [
+        {
+            'seq_length': 4096,
+            'micro_batch_size': 1,
+        },
+    ])
+    @pytest.mark.parametrize('config_kv', [
+        {
+            'use_cpu_initialization': True,
+            'bf16': True,
+            'num_layers': 1,
+            'hidden_size': 5120,
+            'num_attention_heads': 64,
+            'num_query_groups': 8,
+            'kv_channels': 128,
+            'attention_dropout': 0.0,
+            'qk_layernorm': True,
+        },
+    ])
+    @pytest.mark.parametrize('steps', [10])
+    def test_self_attention(self, inputs_kv, config_kv, steps, request):
+        config = TransformerConfig(**config_kv)
+
+        if config.bf16:
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+
+        module_spec = ModuleSpec(
+            module=SelfAttention,
+            params={'attn_mask_type': AttnMaskType.causal},
+            submodules=SelfAttentionSubmodules(
+                linear_qkv=TELayerNormColumnParallelLinear,
+                core_attention=TEDotProductAttention,
+                linear_proj=TERowParallelLinear,
+                q_layernorm=TENorm if config.qk_layernorm else IdentityOp,
+                k_layernorm=TENorm if config.qk_layernorm else IdentityOp,
+            ),
+        )
+        model = build_module(
+            module_spec,
+            config=config,
+            layer_number=0,
+        )
+        model, optimizer = self.setup_model_and_optimizer(config, model)
+
+        for step in range(steps):
+            inputs = (
+                torch.randn(
+                    (
+                        inputs_kv['seq_length'],
+                        inputs_kv['micro_batch_size'],
+                        config.hidden_size
+                    ),
+                    dtype=dtype
+                ).cuda(),
+                torch.triu(
+                    torch.ones(
+                        (
+                            inputs_kv['seq_length'],
+                            inputs_kv['seq_length']
+                        ),
+                        dtype=torch.bool
+                    ), diagonal=1
+                ).unsqueeze(0).unsqueeze(0).cuda(),
+            )
+            output, bias = model(*inputs)
+            merged_output = output + bias
+            loss = merged_output.mean()
+            loss.backward()
+
+            self.save_output(
+                [*inputs],
+                [merged_output],
+                optimizer.get_parameters(),
+                optimizer.get_main_grads_for_grad_norm(),
+                step,
+                request,
+            )
+
+            optimizer.step()

--- a/tests/numerical_tests/modules/test_bda.py
+++ b/tests/numerical_tests/modules/test_bda.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+
+from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.spec_utils import build_module
+from tests.numerical_tests.modules.test_module import TestModule
+
+class TestBDA(TestModule):
+    """
+    Test BDA (Bias-Dropout-Add)
+    """
+
+    @pytest.mark.parametrize('inputs_kv', [
+        {
+            'seq_length': 4096,
+            'micro_batch_size': 1,
+        },
+    ])
+    @pytest.mark.parametrize('config_kv', [
+        {
+            'use_cpu_initialization': True,
+            'bf16': True,
+            'num_layers': 1,
+            'num_attention_heads': 64,
+            'kv_channels': 128,
+            'hidden_dropout': 0.0,
+            'attention_dropout': 0.0,
+        },
+    ])
+    @pytest.mark.parametrize('steps', [10])
+    def test_bda(self, inputs_kv, config_kv, steps, request):
+        config = TransformerConfig(**config_kv)
+
+        if config.bf16:
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+
+        model = build_module(get_bias_dropout_add)
+
+        for step in range(steps):
+            mlp_input = torch.randn(
+                (
+                    inputs_kv['seq_length'],
+                    inputs_kv['micro_batch_size'],
+                    config.num_attention_heads,
+                    config.kv_channels,
+                ),
+                dtype=dtype,
+                requires_grad=True,
+            )
+            mlp_bias = torch.randn(
+                (
+                    inputs_kv['seq_length'],
+                    inputs_kv['micro_batch_size'],
+                    config.num_attention_heads,
+                    config.kv_channels,
+                ),
+                dtype=dtype,
+                requires_grad=True,
+            )
+            residual = torch.randn(
+                (
+                    inputs_kv['seq_length'],
+                    inputs_kv['micro_batch_size'],
+                    config.num_attention_heads,
+                    config.kv_channels,
+                ),
+                dtype=dtype,
+                requires_grad=True,
+            )
+            output = model(training=True, fused=config.bias_dropout_fusion)(
+                (mlp_input.cuda(), mlp_bias.cuda()), residual.cuda(), config.hidden_dropout
+            )
+            loss = output.mean()
+            loss.backward()
+
+            self.save_output(
+                [mlp_input, mlp_bias, residual],
+                [output],
+                [],
+                [mlp_input.grad, mlp_bias.grad, residual.grad],
+                step,
+                request,
+            )

--- a/tests/numerical_tests/modules/test_layer_norm.py
+++ b/tests/numerical_tests/modules/test_layer_norm.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import TENorm
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from tests.numerical_tests.modules.test_module import TestModule
+
+
+class TestLayerNorm(TestModule):
+    """
+    Test LayerNorm
+    """
+
+    @pytest.mark.parametrize('inputs_kv', [
+        {
+            'seq_length': 4096,
+            'micro_batch_size': 1,
+        },
+    ])
+    @pytest.mark.parametrize('config_kv', [
+        {
+            'use_cpu_initialization': True,
+            'bf16': True,
+            'num_layers': 1,
+            'hidden_size': 5120,
+            'num_attention_heads': 1,
+            'normalization': 'RMSNorm',
+        },
+    ])
+    @pytest.mark.parametrize('steps', [10])
+    def test_layer_norm(self, inputs_kv, config_kv, steps, request):
+        config = TransformerConfig(**config_kv)
+
+        if config.bf16:
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+
+        module_spec = ModuleSpec(module=TENorm)
+
+        model = build_module(
+            module_spec,
+            config=config,
+            hidden_size=config_kv['hidden_size'],
+        )
+        model, optimizer = self.setup_model_and_optimizer(config, model)
+
+        for step in range(steps):
+            inputs = (
+                torch.randn(
+                    (
+                        inputs_kv['seq_length'],
+                        inputs_kv['micro_batch_size'],
+                        config.hidden_size
+                    ),
+                    dtype=dtype
+                ).cuda(),
+            )
+            output = model(*inputs)
+            loss = output.mean()
+            loss.backward()
+
+            self.save_output(
+                [*inputs],
+                [output],
+                optimizer.get_parameters(),
+                optimizer.get_main_grads_for_grad_norm(),
+                step,
+                request,
+            )
+
+            optimizer.step()

--- a/tests/numerical_tests/modules/test_mlp.py
+++ b/tests/numerical_tests/modules/test_mlp.py
@@ -1,0 +1,80 @@
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear, TERowParallelLinear
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.mlp import MLP, MLPSubmodules
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from tests.numerical_tests.modules.test_module import TestModule
+
+
+class TestMLP(TestModule):
+    """
+    Test MLP
+    """
+
+    @pytest.mark.parametrize('inputs_kv', [
+        {
+            'seq_length': 4096,
+            'micro_batch_size': 1,
+        },
+    ])
+    @pytest.mark.parametrize('config_kv', [
+        {
+            'use_cpu_initialization': True,
+            'bf16': True,
+            'num_layers': 1,
+            'hidden_size': 5120,
+            'num_attention_heads': 1,
+            'add_bias_linear': False,
+            'gated_linear_unit': torch.nn.functional.silu,
+        },
+    ])
+    @pytest.mark.parametrize('steps', [10])
+    def test_mlp(self, inputs_kv, config_kv, steps, request):
+        config = TransformerConfig(**config_kv)
+
+        if config.bf16:
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+
+        module_spec = ModuleSpec(
+            module=MLP,
+            submodules=MLPSubmodules(
+                linear_fc1=TELayerNormColumnParallelLinear,
+                linear_fc2=TERowParallelLinear,
+            ),
+        )
+
+        model = build_module(
+            module_spec,
+            config=config,
+        )
+        model, optimizer = self.setup_model_and_optimizer(config, model)
+
+        for step in range(steps):
+            inputs = (
+                torch.randn(
+                    (
+                        inputs_kv['seq_length'],
+                        inputs_kv['micro_batch_size'],
+                        config.hidden_size
+                    ),
+                    dtype=dtype
+                ).cuda(),
+            )
+            output, _ = model(*inputs)
+            loss = output.mean()
+            loss.backward()
+
+            self.save_output(
+                [*inputs],
+                [output],
+                optimizer.get_parameters(),
+                optimizer.get_main_grads_for_grad_norm(),
+                step,
+                request,
+            )
+
+            optimizer.step()

--- a/tests/numerical_tests/modules/test_moe_layer.py
+++ b/tests/numerical_tests/modules/test_moe_layer.py
@@ -1,0 +1,128 @@
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import TEColumnParallelLinear, TERowParallelLinear
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.moe.experts import GroupedMLP
+from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
+from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from tests.numerical_tests.modules.test_module import TestModule
+from tests.numerical_tests.modules.test_utilities import Utils
+
+
+class TestMoELayer(TestModule):
+    """
+    Test MoELayer
+    """
+
+    def setup_parallelism(self):
+        expert_model_parallel_size = 8
+        assert Utils.world_size == expert_model_parallel_size
+        Utils.initialize_model_parallel(**{
+            'expert_model_parallel_size': expert_model_parallel_size
+        })
+
+    def setup_random_seed(self):
+        seed = 42 + 10 * torch.distributed.get_rank()
+        torch.manual_seed(seed)
+        model_parallel_cuda_manual_seed(seed)
+
+    @pytest.mark.parametrize('inputs_kv', [
+        {
+            'seq_length': 4096,
+            'micro_batch_size': 1,
+        },
+    ])
+    @pytest.mark.parametrize('config_kv', [
+        {
+            'use_cpu_initialization': True,
+            'bf16': True,
+            'num_layers': 1,
+            'hidden_size': 5120,
+            'num_attention_heads': 1,
+            'add_bias_linear': False,
+            'gated_linear_unit': torch.nn.functional.silu,
+            'expert_model_parallel_size': 8,
+            'num_moe_experts': 64,
+            'moe_ffn_hidden_size': 2160,
+            'moe_router_load_balancing_type': 'seq_aux_loss',
+            'moe_router_score_function': 'sigmoid',
+            'moe_aux_loss_score_function': 'softmax',
+            'moe_router_topk': 8,
+            'moe_aux_loss_coeff': 1e-3,
+            'moe_shared_expert_overlap': True,
+            'moe_grouped_gemm': True,
+            'moe_use_legacy_grouped_gemm': True,
+            'moe_token_dispatcher_type': 'alltoall',
+            'moe_router_dtype': 'fp32',
+            'moe_permute_fusion': True,
+        },
+    ])
+    @pytest.mark.parametrize('steps', [10])
+    def test_moe_layer(self, inputs_kv, config_kv, steps, request):
+        config = TransformerConfig(**config_kv)
+
+        if config.bf16:
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+
+        module_spec = ModuleSpec(
+            module=MoELayer,
+            submodules=MoESubmodules(
+                experts=ModuleSpec(
+                    module=GroupedMLP,
+                    submodules=None
+                ),
+                shared_experts=ModuleSpec(
+                    module=SharedExpertMLP,
+                    params={"gate": False},
+                    submodules=MLPSubmodules(
+                        linear_fc1=TEColumnParallelLinear,
+                        linear_fc2=TERowParallelLinear,
+                    )
+                )
+            )
+        )
+
+        model = build_module(
+            module_spec,
+            config=config,
+        )
+        model, optimizer = self.setup_model_and_optimizer(config, model)
+
+        for step in range(steps):
+            inputs = (
+                torch.randn(
+                    (
+                        inputs_kv['seq_length'],
+                        inputs_kv['micro_batch_size'],
+                        config.hidden_size
+                    ),
+                    dtype=dtype
+                ).cuda(),
+            )
+            output, _ = model(*inputs)
+            loss = output.mean()
+            loss.backward()
+
+            assert hasattr(optimizer, 'chained_optimizers')
+            parameters = []
+            grads = []
+            for chained_optimizer in optimizer.chained_optimizers:
+                parameters += chained_optimizer.get_parameters()
+                grads += chained_optimizer.get_main_grads_for_grad_norm()
+
+            self.save_output(
+                [*inputs],
+                [output],
+                parameters,
+                grads,
+                step,
+                request,
+            )
+
+            optimizer.step()

--- a/tests/numerical_tests/modules/test_rope.py
+++ b/tests/numerical_tests/modules/test_rope.py
@@ -1,0 +1,88 @@
+import pytest
+import torch
+
+from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.module import Float16Module
+from tests.numerical_tests.modules.test_module import TestModule
+
+class TestRoPE(TestModule):
+    """
+    Test RoPE
+    """
+
+    @pytest.mark.parametrize('inputs_kv', [
+        {
+            'seq_length': 4096,
+            'micro_batch_size': 1,
+        },
+    ])
+    @pytest.mark.parametrize('config_kv', [
+        {
+            'use_cpu_initialization': True,
+            'bf16': True,
+            'num_layers': 1,
+            'num_attention_heads': 64,
+            'kv_channels': 128,
+        },
+    ])
+    @pytest.mark.parametrize('rope_kv', [
+        {
+            'rotary_percent': 1.0,
+        },
+    ])
+    @pytest.mark.parametrize('steps', [10])
+    def test_rope(self, inputs_kv, config_kv, rope_kv, steps, request):
+        config = TransformerConfig(**config_kv)
+
+        if config.bf16:
+            dtype = torch.bfloat16
+        else:
+            dtype = torch.float32
+
+        model = RotaryEmbedding(
+            kv_channels=config.kv_channels,
+            rotary_percent=rope_kv['rotary_percent'],
+        )
+        model = model.cuda()
+        if config.bf16:
+            model = Float16Module(config, model)
+
+        for step in range(steps):
+            query = torch.randn(
+                (
+                    inputs_kv['seq_length'],
+                    inputs_kv['micro_batch_size'],
+                    config.num_attention_heads,
+                    config.kv_channels,
+                ),
+                dtype=dtype,
+                requires_grad=True,
+            )
+            key = torch.randn(
+                (
+                    inputs_kv['seq_length'],
+                    inputs_kv['micro_batch_size'],
+                    config.num_attention_heads,
+                    config.kv_channels,
+                ),
+                dtype=dtype,
+                requires_grad=True,
+            )
+            rotary_pos_emb = model(inputs_kv['seq_length'])
+            rotary_pos_emb = (rotary_pos_emb,) * 2
+            q_pos_emb, k_pos_emb = rotary_pos_emb
+            query_output = apply_rotary_pos_emb(query.cuda(), q_pos_emb, config=config)
+            key_output = apply_rotary_pos_emb(key.cuda(), k_pos_emb, config=config)
+            loss = query_output.mean() + key_output.mean()
+            loss.backward()
+
+            self.save_output(
+                [query, key],
+                [query_output, key_output],
+                [q_pos_emb, k_pos_emb],
+                [query.grad, key.grad],
+                step,
+                request,
+            )


### PR DESCRIPTION
Add test cases for transformer block in GPT-like models to numerical tests. Including:
- Layer-norm (TE).
- RoPE.
- Attention (GQA).
- MLP.
- MoE layer.
- Bias-dropout-add (fused).