### PR TITLE
Checkpoint - Add argument for checkpoint upload log directory

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2034,6 +2034,8 @@ def _add_checkpointing_args(parser):
                             'https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account for details')
     group.add_argument('--ckpt-upload-blob-concurrency', type=str, default='AUTO',
                        help='Number of concurrent requests that can occur during Azure blob upload.')
+    group.add_argument('--ckpt-upload-log-dir', type=str, default='$HOME/.azcopy',
+                       help='Log directory for checkpoint upload.')
     group.add_argument('--ckpt-isolated-save', action='store_true',
                        help='Whether the checkpoints need to be saved to multiple isolated places.')
     return parser

--- a/megatron/training/ckpt_utils.py
+++ b/megatron/training/ckpt_utils.py
@@ -44,6 +44,7 @@ class CkptUploadQueue:
         self.blob_path = args.ckpt_upload_blob_path.rstrip("/")
         self.blob_sas_path = args.ckpt_upload_blob_sas_path
         self.blob_concurrency = args.ckpt_upload_blob_concurrency
+        self.log_dir = args.ckpt_upload_log_dir
 
         self.upload_tasks = queue.Queue()
         self._running = True
@@ -129,7 +130,10 @@ class CkptUploadQueue:
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env={"AZCOPY_CONCURRENCY_VALUE": self.blob_concurrency},
+            env={
+                "AZCOPY_CONCURRENCY_VALUE": self.blob_concurrency,
+                "AZCOPY_LOG_LOCATION": self.log_dir,
+            },
         )
         stdout, stderr = await proc.communicate()
         if stdout:

--- a/megatron/training/ckpt_utils.py
+++ b/megatron/training/ckpt_utils.py
@@ -44,7 +44,7 @@ class CkptUploadQueue:
         self.blob_path = args.ckpt_upload_blob_path.rstrip("/")
         self.blob_sas_path = args.ckpt_upload_blob_sas_path
         self.blob_concurrency = args.ckpt_upload_blob_concurrency
-        self.log_dir = args.ckpt_upload_log_dir
+        self.log_dir = os.path.expandvars(args.ckpt_upload_log_dir)
 
         self.upload_tasks = queue.Queue()
         self._running = True


### PR DESCRIPTION
Add argument for checkpoint upload log directory, use `--ckpt-upload-log-dir /path/to/blob/$JOB/$TASK_INDEX` to enable.