### PR TITLE
Tests - Disable auto version resolving for triton to avoid test crashes in NVIDIA pipeline

### DIFF
--- a/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
@@ -3,7 +3,7 @@ set -e
 pip install -r requirements_ci.txt
 CAUSAL_CONV1D_FORCE_BUILD=TRUE pip install git+https://github.com/Dao-AILab/causal-conv1d.git@v1.2.2.post1
 pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.2
-MAMBA_FORCE_BUILD=TRUE pip install git+https://github.com/state-spaces/mamba.git@v2.2.0 triton==3.3.1
+MAMBA_FORCE_BUILD=TRUE pip install git+https://github.com/state-spaces/mamba.git@v2.2.0
 apt purge -y python3-blinker
 pip install flask flask-restful tiktoken tensorstore
 

--- a/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
+++ b/tests/test_utils/ltp_scripts/run_unit_tests_nvidia_h200_1n8g.sh
@@ -3,7 +3,7 @@ set -e
 pip install -r requirements_ci.txt
 CAUSAL_CONV1D_FORCE_BUILD=TRUE pip install git+https://github.com/Dao-AILab/causal-conv1d.git@v1.2.2.post1
 pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.2
-MAMBA_FORCE_BUILD=TRUE pip install git+https://github.com/state-spaces/mamba.git@v2.2.0
+MAMBA_FORCE_BUILD=TRUE pip install git+https://github.com/state-spaces/mamba.git@v2.2.0 triton==3.3.1
 apt purge -y python3-blinker
 pip install flask flask-restful tiktoken tensorstore
 


### PR DESCRIPTION
Disables auto version resolving for triton dependency in NVIDIA pipeline which would cause tests to crash.