### PR TITLE
Hot Fix - Fix potential inconsistent w/v tensor list length in distributed checkpoint loading when DP changes

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -563,13 +563,18 @@ class GroupedMLP(MegatronModule):
                         local_expert_dict['v_tensors'], local_expert_dict['v_lens']
                     )
                     first_glu_idx = local_expert_dict['first_glu_idx']
+                    fill_tensor = None
+                    if len(w_tensors):
+                        fill_tensor = w_tensors[0].new_empty(0)
+                    elif len(v_tensors):
+                        fill_tensor = v_tensors[0].new_empty(0)
                     if first_glu_idx == 0:
                         res += [
-                            x for x in itertools.chain(*itertools.zip_longest(w_tensors, v_tensors))
+                            x for x in itertools.chain(*itertools.zip_longest(w_tensors, v_tensors, fillvalue=fill_tensor))
                         ]
                     else:
                         res += [
-                            x for x in itertools.chain(*itertools.zip_longest(v_tensors, w_tensors))
+                            x for x in itertools.chain(*itertools.zip_longest(v_tensors, w_tensors, fillvalue=fill_tensor))
                         ]
                 return torch.cat(res)
             elif isinstance(sub_state_dict, list) and sub_state_dict[0].ndim == 1:


### PR DESCRIPTION
In legacy grouped GeMM with GLU, experts need to be split along dim-0 for DP sharding, and along dim-2 for GLU.

The following sketch, which is from the function comment of `sh_ten_build_fn` in `megatron/core/transformer/moe/experts.py`, shows a case of DP sharding for expert weight:

```
|................|           |........|........|
|............FFFF|           |........|....BBBB|
|FFFFFFFFFFFFFFFF|     ->    |AAAAAAAA|BBBBBBBB|
|FFFFFFFFFFFFFFFF|           |AAAAAAAA|BBBBBBBB|
|FF..............|           |AA......|........|
|................|           |........|........|
```

There are 3 A-chunks (for W) and 3 B-chunks (for V). However, the number of A/B chunks can be non-equal in some sharding conditions, and the final `torch.cat` in `sh_ten_merge_fn` can fail due to not accepting `None` elements padded by previous `zip_longest`.

This commit pads w/v tensors with empty tensors instead of None for such cases.