### PR TITLE
fix: remove unregistered jet-api from Dockerfile.linting (dependency confusion)

### DIFF
--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -29,6 +29,6 @@ FROM main as jet
 ARG CACHEBUST=0
 RUN --mount=type=secret,id=JET_INDEX_URLS \
       JET_INDEX_URLS=$(cat /run/secrets/JET_INDEX_URLS) && \
-      pip install "jet-client~=2.0" jet-api --upgrade $JET_INDEX_URLS
+      pip install "jet-client~=2.0" --upgrade $JET_INDEX_URLS
 ENV PATH="$PATH:/opt/jet/bin"
 ###


### PR DESCRIPTION
## Summary

`Dockerfile.linting` installs `jet-api` via pip in the `jet` build stage. `jet-api` is an internal NVIDIA CI orchestration package that is not published on PyPI.

The private index URL is injected via a Docker build secret (`JET_INDEX_URLS`) and appended as a trailing positional argument. If the secret is absent or the variable expansion produces an empty string, pip resolves `jet-api` exclusively from PyPI — where the name is currently unregistered and squattable.

This PR removes `jet-api` from the install command. `jet-client` (which is pinned to `~=2.0`) is retained as it is the primary package needed for the linting stage.

## Changes

- `Dockerfile.linting`: remove `jet-api` from the `pip install` line in the `jet` stage

## Security Impact

Dependency confusion — `jet-api` is unregistered on PyPI. An attacker registering the name gains code execution inside CI build environments that use this Dockerfile stage without providing the private index secret.

## Test plan

- [ ] Confirm the `jet` build stage still functions correctly without `jet-api`
- [ ] If `jet-api` is required, install it using an explicit `--extra-index-url` flag (not a trailing positional argument) so the private index is always consulted
